### PR TITLE
Add project overview dashboard and project workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^8.57.0",
@@ -1046,6 +1047,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3658,6 +3668,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,12 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
+    "@eslint/js": "^8.57.0",
+    "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
@@ -23,13 +26,11 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.8",
+    "globals": "^15.8.0",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
-    "vite": "^5.2.11",
-    "globals": "^15.8.0",
-    "@types/node": "^20.14.2",
-    "@eslint/js": "^8.57.0",
-    "typescript-eslint": "^7.12.0"
+    "typescript-eslint": "^7.12.0",
+    "vite": "^5.2.11"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
+import { Route, Routes } from 'react-router-dom';
+
 import Home from './pages/Home';
+import ProjectPage from './pages/ProjectPage';
 
 function App() {
   return (
     <div className="min-h-screen bg-slate-950 font-sans text-slate-100">
       <header className="border-b border-slate-800 bg-slate-900/70 backdrop-blur">
-        <div className="mx-auto flex max-w-5xl flex-col gap-2 px-6 py-6 text-center sm:flex-row sm:items-center sm:justify-between">
+        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-6 py-6 text-center sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-2xl font-semibold tracking-tight text-slate-100 sm:text-3xl">
             Tabletop Creator – Your Friendly Game Design Companion
           </h1>
@@ -16,12 +19,15 @@ function App() {
         </div>
       </header>
 
-      <main className="mx-auto flex max-w-5xl flex-1 flex-col gap-16 px-6 py-16">
-        <Home />
+      <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-16 px-6 py-12 sm:py-16">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/projects/:projectId" element={<ProjectPage />} />
+        </Routes>
       </main>
 
       <footer className="border-t border-slate-800 bg-slate-900/70">
-        <div className="mx-auto flex max-w-5xl flex-col items-center gap-2 px-6 py-6 text-center text-sm text-slate-400 sm:flex-row sm:justify-between">
+        <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-6 py-6 text-center text-sm text-slate-400 sm:flex-row sm:justify-between">
           <p>&copy; {new Date().getFullYear()} Tabletop Creator. All rights reserved.</p>
           <p className="text-xs sm:text-sm">Crafted with Vite, React, TypeScript, and Tailwind CSS.</p>
         </div>

--- a/src/components/ImageAssetBrowser.tsx
+++ b/src/components/ImageAssetBrowser.tsx
@@ -1,0 +1,175 @@
+import { ChangeEvent, useMemo, useState } from 'react';
+
+import { AssetInput, ProjectAsset } from '../context/ProjectContext';
+
+interface ImageAssetBrowserProps {
+  open: boolean;
+  assets: ProjectAsset[];
+  onClose: () => void;
+  onAddAssets: (assets: AssetInput[]) => void;
+  onRemoveAssets: (assetIds: string[]) => void;
+  onLocateAsset: (assetId: string) => void;
+}
+
+function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets, onLocateAsset }: ImageAssetBrowserProps) {
+  const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
+  const [previewAssetId, setPreviewAssetId] = useState<string | null>(null);
+
+  const previewAsset = useMemo(() => assets.find((asset) => asset.id === previewAssetId) ?? null, [assets, previewAssetId]);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+
+    if (files.length === 0) {
+      return;
+    }
+
+    const mapped: AssetInput[] = files.map((file) => ({
+      name: file.name.replace(/\.[^.]+$/, ''),
+      url: URL.createObjectURL(file),
+    }));
+
+    onAddAssets(mapped);
+    event.target.value = '';
+  };
+
+  const toggleSelected = (assetId: string) => {
+    setSelectedAssets((prev) =>
+      prev.includes(assetId) ? prev.filter((id) => id !== assetId) : [...prev, assetId],
+    );
+  };
+
+  const clearStateAndClose = () => {
+    setSelectedAssets([]);
+    setPreviewAssetId(null);
+    onClose();
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-6 backdrop-blur">
+      <div className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-slate-800 bg-slate-950/95 shadow-2xl shadow-black/60">
+        <div className="flex items-center justify-between border-b border-slate-800 px-8 py-6">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300/80">Image Library</p>
+            <h2 className="mt-1 text-xl font-semibold text-white">Manage your project visuals</h2>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                if (selectedAssets.length === 1) {
+                  onLocateAsset(selectedAssets[0]);
+                }
+              }}
+              disabled={selectedAssets.length !== 1}
+              className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold text-slate-300 transition disabled:cursor-not-allowed disabled:opacity-50 hover:border-emerald-500 hover:text-emerald-200"
+            >
+              Locate usage
+            </button>
+            <button
+              type="button"
+              onClick={() => onRemoveAssets(selectedAssets)}
+              disabled={selectedAssets.length === 0}
+              className="rounded-full border border-rose-500/60 px-4 py-2 text-xs font-semibold text-rose-200 transition disabled:cursor-not-allowed disabled:opacity-50 hover:bg-rose-500/10"
+            >
+              Delete selected
+            </button>
+            <label className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-emerald-500 px-4 py-2 text-xs font-semibold text-slate-950 transition hover:bg-emerald-400">
+              <input type="file" accept="image/*" multiple className="hidden" onChange={handleFileChange} />
+              Add images
+            </label>
+            <button
+              type="button"
+              onClick={clearStateAndClose}
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-700/70 text-slate-300 transition hover:border-slate-500 hover:text-white"
+              aria-label="Close image library"
+            >
+              <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M6.22 6.22a.75.75 0 011.06 0L12 10.94l4.72-4.72a.75.75 0 111.06 1.06L13.06 12l4.72 4.72a.75.75 0 11-1.06 1.06L12 13.06l-4.72 4.72a.75.75 0 11-1.06-1.06L10.94 12 6.22 7.28a.75.75 0 010-1.06z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-1 overflow-hidden">
+          <div className="flex-1 overflow-y-auto px-8 py-6">
+            {assets.length === 0 ? (
+              <div className="flex h-full flex-col items-center justify-center rounded-2xl border border-dashed border-slate-700/70 bg-slate-900/50 p-12 text-center">
+                <p className="text-lg font-semibold text-slate-200">No images yet</p>
+                <p className="mt-2 max-w-md text-sm text-slate-400">
+                  Use the "Add images" button to import concept art, icons, or reference boards for this project.
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+                {assets.map((asset) => {
+                  const selected = selectedAssets.includes(asset.id);
+                  return (
+                    <div
+                      key={asset.id}
+                      className={`group relative overflow-hidden rounded-2xl border transition ${
+                        selected ? 'border-emerald-500/70' : 'border-slate-800/80'
+                      }`}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => setPreviewAssetId(asset.id)}
+                        className="relative block h-40 w-full overflow-hidden bg-slate-900/80"
+                      >
+                        <img
+                          src={asset.url}
+                          alt={asset.name}
+                          className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                        />
+                      </button>
+                      <div className="flex items-center justify-between gap-2 border-t border-slate-800/80 bg-slate-900/80 px-3 py-3">
+                        <p className="truncate text-xs font-semibold text-slate-200" title={asset.name}>
+                          {asset.name}
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => toggleSelected(asset.id)}
+                          className={`flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold transition ${
+                            selected
+                              ? 'border-emerald-500/70 bg-emerald-500/20 text-emerald-200'
+                              : 'border-slate-700/70 text-slate-300 hover:border-emerald-500 hover:text-emerald-200'
+                          }`}
+                        >
+                          {selected ? '✓' : '+'}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="hidden w-64 border-l border-slate-800/80 bg-slate-950/90 p-6 lg:block">
+            <h3 className="text-sm font-semibold text-slate-200">Preview</h3>
+            {previewAsset ? (
+              <div className="mt-4 space-y-3">
+                <div className="overflow-hidden rounded-xl border border-slate-800/80">
+                  <img src={previewAsset.url} alt={previewAsset.name} className="w-full" />
+                </div>
+                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Title</p>
+                <p className="text-sm font-semibold text-white">{previewAsset.name}</p>
+              </div>
+            ) : (
+              <p className="mt-4 text-xs text-slate-500">Select an asset to see a larger preview.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ImageAssetBrowser;

--- a/src/components/NewItemDialog.tsx
+++ b/src/components/NewItemDialog.tsx
@@ -1,0 +1,181 @@
+import { FormEvent, useMemo, useState } from 'react';
+
+import { ItemInput, ProjectItemType } from '../context/ProjectContext';
+import { ITEM_TYPE_DEFINITIONS } from '../constants/itemOptions';
+
+interface NewItemDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (item: ItemInput) => void;
+}
+
+const defaultState = {
+  name: '',
+  itemType: 'board' as ProjectItemType,
+  variant: ITEM_TYPE_DEFINITIONS[0].variants[0],
+  customDetails: '',
+};
+
+function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
+  const [formState, setFormState] = useState(defaultState);
+
+  const typeDefinition = useMemo(
+    () => ITEM_TYPE_DEFINITIONS.find((definition) => definition.id === formState.itemType) ?? ITEM_TYPE_DEFINITIONS[0],
+    [formState.itemType],
+  );
+
+  const resetForm = () => {
+    setFormState(defaultState);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedName = formState.name.trim();
+    if (!trimmedName) {
+      return;
+    }
+
+    onSubmit({
+      name: trimmedName,
+      type: formState.itemType,
+      variant: formState.variant,
+      customDetails:
+        formState.variant.toLowerCase().includes('custom') || formState.itemType === 'custom'
+          ? formState.customDetails.trim() || undefined
+          : undefined,
+    });
+
+    resetForm();
+    onClose();
+  };
+
+  const handleClose = () => {
+    resetForm();
+    onClose();
+  };
+
+  const showCustomField =
+    formState.variant.toLowerCase().includes('custom') || formState.itemType === 'custom';
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur">
+      <div className="w-full max-w-2xl rounded-3xl border border-slate-800 bg-slate-950/95 shadow-2xl shadow-black/60">
+        <div className="flex items-center justify-between border-b border-slate-800 px-6 py-5">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300/80">New Item</p>
+            <h2 className="mt-2 text-xl font-semibold text-white">Add to this project</h2>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-700/70 text-slate-300 transition hover:border-slate-500 hover:text-white"
+            aria-label="Close"
+          >
+            <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M6.22 6.22a.75.75 0 011.06 0L12 10.94l4.72-4.72a.75.75 0 111.06 1.06L13.06 12l4.72 4.72a.75.75 0 11-1.06 1.06L12 13.06l-4.72 4.72a.75.75 0 11-1.06-1.06L10.94 12 6.22 7.28a.75.75 0 010-1.06z"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6 px-6 py-5">
+          <label className="block text-sm font-semibold text-slate-200">
+            Item title
+            <input
+              value={formState.name}
+              onChange={(event) => setFormState((state) => ({ ...state, name: event.target.value }))}
+              placeholder="e.g. Quest Log Poster"
+              className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-2 text-base text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+              required
+            />
+          </label>
+
+          <div className="grid grid-cols-2 gap-3">
+            {ITEM_TYPE_DEFINITIONS.map((type) => (
+              <button
+                key={type.id}
+                type="button"
+                onClick={() =>
+                  setFormState((state) => ({
+                    ...state,
+                    itemType: type.id,
+                    variant: type.variants[0],
+                    customDetails: '',
+                  }))
+                }
+                className={`rounded-2xl border px-4 py-4 text-left transition ${
+                  formState.itemType === type.id
+                    ? 'border-emerald-500/70 bg-emerald-500/10 text-emerald-100'
+                    : 'border-slate-800/80 bg-slate-950/50 text-slate-300 hover:border-slate-600 hover:bg-slate-900'
+                }`}
+              >
+                <p className="text-sm font-semibold">{type.name}</p>
+                <p className="mt-1 text-xs text-slate-400">{type.description}</p>
+              </button>
+            ))}
+          </div>
+
+          <div className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Format</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {typeDefinition.variants.map((variant) => (
+                <button
+                  key={variant}
+                  type="button"
+                  onClick={() => setFormState((state) => ({ ...state, variant }))}
+                  className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                    formState.variant === variant
+                      ? 'bg-emerald-500 text-slate-950'
+                      : 'bg-slate-900 text-slate-300 hover:bg-slate-800'
+                  }`}
+                >
+                  {variant}
+                </button>
+              ))}
+            </div>
+
+            {showCustomField && (
+              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                Custom details
+                <input
+                  value={formState.customDetails}
+                  onChange={(event) => setFormState((state) => ({ ...state, customDetails: event.target.value }))}
+                  placeholder="Add size or notes"
+                  className="mt-2 w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+                />
+              </label>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-3 border-t border-slate-800/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-slate-400">You can refine this item's layout once it's added.</p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-full border border-slate-700/70 px-5 py-2 text-sm font-semibold text-slate-300 transition hover:border-slate-500 hover:text-white"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+              >
+                Add item
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default NewItemDialog;

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -1,0 +1,216 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+import { ItemInput, ProjectItemType } from '../context/ProjectContext';
+import { ITEM_TYPE_DEFINITIONS } from '../constants/itemOptions';
+
+interface NewProjectDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (data: { name: string; initialItem?: ItemInput }) => void;
+}
+
+const emptyFormState = {
+  name: '',
+  itemName: '',
+  itemType: 'board' as ProjectItemType,
+  variant: ITEM_TYPE_DEFINITIONS[0].variants[0],
+  customDetails: '',
+};
+
+function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
+  const [formState, setFormState] = useState(emptyFormState);
+
+  useEffect(() => {
+    if (open) {
+      setFormState(emptyFormState);
+    }
+  }, [open]);
+
+  const typeDefinition = useMemo(
+    () => ITEM_TYPE_DEFINITIONS.find((definition) => definition.id === formState.itemType) ?? ITEM_TYPE_DEFINITIONS[0],
+    [formState.itemType],
+  );
+
+  useEffect(() => {
+    setFormState((state) => ({
+      ...state,
+      variant: typeDefinition.variants[0],
+      customDetails: '',
+    }));
+  }, [typeDefinition]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedName = formState.name.trim();
+    if (!trimmedName) {
+      return;
+    }
+
+    const trimmedItemName = formState.itemName.trim();
+    let initialItem: ItemInput | undefined;
+
+    if (trimmedItemName) {
+      initialItem = {
+        name: trimmedItemName,
+        type: formState.itemType,
+        variant: formState.variant,
+        customDetails:
+          formState.variant.toLowerCase().includes('custom') || formState.itemType === 'custom'
+            ? formState.customDetails.trim() || undefined
+            : undefined,
+      };
+    }
+
+    onCreate({
+      name: trimmedName,
+      initialItem,
+    });
+    onClose();
+  };
+
+  const showCustomField =
+    formState.variant.toLowerCase().includes('custom') || formState.itemType === 'custom';
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur">
+      <div className="w-full max-w-3xl rounded-3xl border border-slate-800 bg-slate-950/95 shadow-2xl shadow-black/60">
+        <div className="flex items-center justify-between border-b border-slate-800 px-8 py-6">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300/80">New Project</p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">Create a tabletop adventure workspace</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-700/70 text-slate-300 transition hover:border-slate-500 hover:text-white"
+            aria-label="Close"
+          >
+            <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M6.22 6.22a.75.75 0 011.06 0L12 10.94l4.72-4.72a.75.75 0 111.06 1.06L13.06 12l4.72 4.72a.75.75 0 11-1.06 1.06L12 13.06l-4.72 4.72a.75.75 0 11-1.06-1.06L10.94 12 6.22 7.28a.75.75 0 010-1.06z"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="grid gap-8 px-8 py-6 sm:grid-cols-2">
+          <div className="space-y-4">
+            <label className="block text-sm font-semibold text-slate-200">
+              Project name
+              <input
+                value={formState.name}
+                onChange={(event) => setFormState((state) => ({ ...state, name: event.target.value }))}
+                placeholder="e.g. Clockwork Isles Campaign"
+                className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-2 text-base text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+                required
+              />
+            </label>
+
+            <div className="rounded-2xl border border-slate-800/80 bg-slate-900/40 p-4">
+              <p className="text-sm font-semibold text-slate-200">First item</p>
+              <p className="mt-1 text-xs text-slate-400">
+                Give your project a head start with the first board, deck, or poster.
+              </p>
+
+              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                Item title
+                <input
+                  value={formState.itemName}
+                  onChange={(event) => setFormState((state) => ({ ...state, itemName: event.target.value }))}
+                  placeholder="e.g. Encounter Deck"
+                  className="mt-2 w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+                />
+              </label>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-2 gap-3">
+              {ITEM_TYPE_DEFINITIONS.map((type) => (
+                <button
+                  key={type.id}
+                  type="button"
+                  onClick={() =>
+                    setFormState((state) => ({
+                      ...state,
+                      itemType: type.id,
+                      variant: type.variants[0],
+                      customDetails: '',
+                    }))
+                  }
+                  className={`rounded-2xl border px-4 py-4 text-left transition ${
+                    formState.itemType === type.id
+                      ? 'border-emerald-500/70 bg-emerald-500/10 text-emerald-100'
+                      : 'border-slate-800/80 bg-slate-950/50 text-slate-300 hover:border-slate-600 hover:bg-slate-900'
+                  }`}
+                >
+                  <p className="text-sm font-semibold">{type.name}</p>
+                  <p className="mt-1 text-xs text-slate-400">{type.description}</p>
+                </button>
+              ))}
+            </div>
+
+            <div className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Format</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {typeDefinition.variants.map((variant) => (
+                  <button
+                    key={variant}
+                    type="button"
+                    onClick={() => setFormState((state) => ({ ...state, variant }))}
+                    className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                      formState.variant === variant
+                        ? 'bg-emerald-500 text-slate-950'
+                        : 'bg-slate-900 text-slate-300 hover:bg-slate-800'
+                    }`}
+                  >
+                    {variant}
+                  </button>
+                ))}
+              </div>
+
+              {showCustomField && (
+                <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                  Custom details
+                  <input
+                    value={formState.customDetails}
+                    onChange={(event) => setFormState((state) => ({ ...state, customDetails: event.target.value }))}
+                    placeholder="Add size or notes"
+                    className="mt-2 w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+                  />
+                </label>
+              )}
+            </div>
+          </div>
+
+          <div className="sm:col-span-2 flex flex-col gap-3 border-t border-slate-800/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-slate-400">You can add more items or assets after your project is created.</p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-full border border-slate-700/70 px-5 py-2 text-sm font-semibold text-slate-300 transition hover:border-slate-500 hover:text-white"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+              >
+                Create project
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default NewProjectDialog;

--- a/src/components/ProjectOverviewPanel.tsx
+++ b/src/components/ProjectOverviewPanel.tsx
@@ -1,0 +1,103 @@
+import { Project } from '../context/ProjectContext';
+
+interface ProjectOverviewPanelProps {
+  projects: Project[];
+  onOpenProject: (projectId: string) => void;
+  onCreateProject: () => void;
+}
+
+function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject }: ProjectOverviewPanelProps) {
+  return (
+    <section className="rounded-3xl border border-slate-800 bg-slate-900/60 shadow-2xl shadow-slate-950/40">
+      <div className="flex flex-col gap-6 p-8 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Project Overview</p>
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            Continue crafting your tabletop worlds
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm text-slate-300 sm:text-base">
+            Access your active projects or start something brand new. Each project keeps boards, decks, posters, and assets neatly
+            organized for fast iteration.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onCreateProject}
+          className="inline-flex items-center justify-center rounded-full border border-emerald-500/60 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:bg-emerald-400/20 hover:text-white"
+        >
+          New Project +
+        </button>
+      </div>
+
+      <div className="border-t border-slate-800/60" />
+
+      <div className="grid gap-6 p-8 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.length === 0 ? (
+          <div className="col-span-full flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-700/70 bg-slate-900/40 px-6 py-12 text-center">
+            <p className="text-lg font-semibold text-slate-200">No projects yet</p>
+            <p className="mt-2 max-w-sm text-sm text-slate-400">When you create your first project it will appear here for quick access.</p>
+            <button
+              type="button"
+              onClick={onCreateProject}
+              className="mt-6 inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+            >
+              Start your first project
+            </button>
+          </div>
+        ) : (
+          projects.map((project) => (
+            <button
+              key={project.id}
+              type="button"
+              onClick={() => onOpenProject(project.id)}
+              className="group flex flex-col rounded-2xl border border-slate-800/80 bg-slate-950/60 p-6 text-left shadow-lg shadow-black/30 transition hover:-translate-y-1 hover:border-emerald-500/70 hover:bg-slate-900/80 hover:shadow-emerald-500/20"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Project</p>
+                  <h3 className="mt-2 text-xl font-semibold text-white transition group-hover:text-emerald-200">
+                    {project.name}
+                  </h3>
+                </div>
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-200 transition group-hover:bg-emerald-400/20">
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    className="h-5 w-5 transform transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                  >
+                    <path
+                      fill="currentColor"
+                      d="M8.75 7.25a.75.75 0 011.5 0v6.69l6.22-6.22a.75.75 0 011.06 1.06l-6.22 6.22h6.69a.75.75 0 010 1.5h-8.5a.75.75 0 01-.75-.75z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <p className="mt-4 text-sm text-slate-400">
+                {project.items.length > 0
+                  ? `${project.items.length} item${project.items.length === 1 ? '' : 's'} ready to refine`
+                  : 'No items added yet — jump in to get started.'}
+              </p>
+              {project.items.length > 0 && (
+                <ul className="mt-4 space-y-2 text-sm text-slate-300">
+                  {project.items.slice(0, 3).map((item) => (
+                    <li key={item.id} className="flex items-center gap-2">
+                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" aria-hidden />
+                      <span>{item.name}</span>
+                    </li>
+                  ))}
+                  {project.items.length > 3 && (
+                    <li className="text-xs uppercase tracking-widest text-slate-500">
+                      +{project.items.length - 3} more
+                    </li>
+                  )}
+                </ul>
+              )}
+            </button>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default ProjectOverviewPanel;

--- a/src/constants/itemOptions.ts
+++ b/src/constants/itemOptions.ts
@@ -1,0 +1,35 @@
+import { ProjectItemType } from '../context/ProjectContext';
+
+export interface ItemTypeDefinition {
+  id: ProjectItemType;
+  name: string;
+  description: string;
+  variants: string[];
+}
+
+export const ITEM_TYPE_DEFINITIONS: ItemTypeDefinition[] = [
+  {
+    id: 'board',
+    name: 'Board',
+    description: 'Design modular boards for your campaign maps or dungeons.',
+    variants: ['Small (18 × 18 in)', 'Medium (24 × 24 in)', 'Large (36 × 36 in)', 'Custom size'],
+  },
+  {
+    id: 'cardDeck',
+    name: 'Card Deck',
+    description: 'Create decks for abilities, encounters, loot, or encounters.',
+    variants: ['Poker (2.5 × 3.5 in)', 'Tarot (2.75 × 4.75 in)', 'Mini (1.75 × 2.5 in)', 'Custom size'],
+  },
+  {
+    id: 'questPoster',
+    name: 'Quest Poster',
+    description: 'Plan quest summaries, lore pages, or narrative beats.',
+    variants: ['A4 (210 × 297 mm)', 'A3 (297 × 420 mm)', 'A2 (420 × 594 mm)', 'Custom size'],
+  },
+  {
+    id: 'custom',
+    name: 'Custom Item',
+    description: 'Anything else you want to keep alongside your project.',
+    variants: ['Custom specification'],
+  },
+];

--- a/src/context/ProjectContext.tsx
+++ b/src/context/ProjectContext.tsx
@@ -1,0 +1,234 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+export type ProjectItemType = 'board' | 'cardDeck' | 'questPoster' | 'custom';
+
+export interface ProjectItem {
+  id: string;
+  name: string;
+  type: ProjectItemType;
+  variant: string;
+  customDetails?: string;
+}
+
+export interface ProjectAsset {
+  id: string;
+  name: string;
+  url: string;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  items: ProjectItem[];
+  assets: ProjectAsset[];
+}
+
+export interface ItemInput {
+  name: string;
+  type: ProjectItemType;
+  variant: string;
+  customDetails?: string;
+}
+
+export interface NewProjectInput {
+  name: string;
+  initialItem?: ItemInput;
+}
+
+export interface AssetInput {
+  name: string;
+  url: string;
+}
+
+interface ProjectContextValue {
+  projects: Project[];
+  createProject: (input: NewProjectInput) => Project;
+  updateProjectName: (projectId: string, name: string) => void;
+  addItemToProject: (projectId: string, item: ItemInput) => ProjectItem | null;
+  addAssetsToProject: (projectId: string, assets: AssetInput[]) => ProjectAsset[];
+  removeAssetsFromProject: (projectId: string, assetIds: string[]) => void;
+}
+
+const ProjectContext = createContext<ProjectContextValue | undefined>(undefined);
+
+const createId = () => crypto.randomUUID();
+
+const initialProjects: Project[] = [
+  {
+    id: createId(),
+    name: 'Mystic Realms Board Game',
+    items: [
+      {
+        id: createId(),
+        name: 'Realm Exploration Board',
+        type: 'board',
+        variant: 'Large (36 × 36 in)',
+      },
+      {
+        id: createId(),
+        name: 'Quest Reference Cards',
+        type: 'cardDeck',
+        variant: 'Tarot (2.75 × 4.75 in)',
+      },
+    ],
+    assets: [
+      {
+        id: createId(),
+        name: 'Forest Illustration',
+        url: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=600&q=60',
+      },
+      {
+        id: createId(),
+        name: 'Quest Icon Set',
+        url: 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=600&q=60',
+      },
+    ],
+  },
+  {
+    id: createId(),
+    name: 'Galactic Outpost Adventure',
+    items: [
+      {
+        id: createId(),
+        name: 'Mission Brief Posters',
+        type: 'questPoster',
+        variant: 'A3 (297 × 420 mm)',
+      },
+    ],
+    assets: [
+      {
+        id: createId(),
+        name: 'Star Map Texture',
+        url: 'https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?auto=format&fit=crop&w=600&q=60',
+      },
+    ],
+  },
+];
+
+export function ProjectProvider({ children }: { children: React.ReactNode }) {
+  const [projects, setProjects] = useState<Project[]>(initialProjects);
+
+  const createProject = (input: NewProjectInput) => {
+    const projectId = createId();
+    const items: ProjectItem[] = input.initialItem
+      ? [
+          {
+            id: createId(),
+            name: input.initialItem.name,
+            type: input.initialItem.type,
+            variant: input.initialItem.variant,
+            customDetails: input.initialItem.customDetails,
+          },
+        ]
+      : [];
+
+    const newProject: Project = {
+      id: projectId,
+      name: input.name,
+      items,
+      assets: [],
+    };
+
+    setProjects((prev) => [...prev, newProject]);
+    return newProject;
+  };
+
+  const updateProjectName = (projectId: string, name: string) => {
+    setProjects((prev) =>
+      prev.map((project) =>
+        project.id === projectId
+          ? {
+              ...project,
+              name,
+            }
+          : project,
+      ),
+    );
+  };
+
+  const addItemToProject = (projectId: string, item: ItemInput) => {
+    const newItem: ProjectItem = {
+      id: createId(),
+      name: item.name,
+      type: item.type,
+      variant: item.variant,
+      customDetails: item.customDetails,
+    };
+
+    setProjects((prev) =>
+      prev.map((project) =>
+        project.id === projectId
+          ? {
+              ...project,
+              items: [...project.items, newItem],
+            }
+          : project,
+      ),
+    );
+
+    return newItem;
+  };
+
+  const addAssetsToProject = (projectId: string, assets: AssetInput[]) => {
+    const mappedAssets: ProjectAsset[] = assets.map((asset) => ({
+      id: createId(),
+      name: asset.name,
+      url: asset.url,
+    }));
+
+    setProjects((prev) =>
+      prev.map((project) =>
+        project.id === projectId
+          ? {
+              ...project,
+              assets: [...project.assets, ...mappedAssets],
+            }
+          : project,
+      ),
+    );
+
+    return mappedAssets;
+  };
+
+  const removeAssetsFromProject = (projectId: string, assetIds: string[]) => {
+    setProjects((prev) =>
+      prev.map((project) =>
+        project.id === projectId
+          ? {
+              ...project,
+              assets: project.assets.filter((asset) => !assetIds.includes(asset.id)),
+            }
+          : project,
+      ),
+    );
+  };
+
+  const value = useMemo(
+    () => ({
+      projects,
+      createProject,
+      updateProjectName,
+      addItemToProject,
+      addAssetsToProject,
+      removeAssetsFromProject,
+    }),
+    [projects],
+  );
+
+  return <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>;
+}
+
+export function useProjects() {
+  const context = useContext(ProjectContext);
+
+  if (!context) {
+    throw new Error('useProjects must be used within a ProjectProvider');
+  }
+
+  return context;
+}
+
+export function findProject(projects: Project[], projectId: string) {
+  return projects.find((project) => project.id === projectId) ?? null;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
+import { ProjectProvider } from './context/ProjectContext';
 import './styles/tailwind.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <ProjectProvider>
+        <App />
+      </ProjectProvider>
+    </BrowserRouter>
   </React.StrictMode>,
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,44 +1,50 @@
-import FeatureCard from '../components/FeatureCard';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-const features = [
-  {
-    title: 'Create & Save Projects',
-    description:
-      'Start new tabletop adventures with structured project workspaces you can revisit any time.',
-  },
-  {
-    title: 'Design With Ease',
-    description:
-      'Use intuitive tools to draft boards, cards, and quest posters without complex setup.',
-  },
-  {
-    title: 'Print or Order',
-    description:
-      'Export print-ready files or connect with partners when you are ready to share your game.',
-  },
-];
+import ProjectOverviewPanel from '../components/ProjectOverviewPanel';
+import NewProjectDialog from '../components/NewProjectDialog';
+import { ItemInput } from '../context/ProjectContext';
+import { useProjects } from '../context/ProjectContext';
 
 function Home() {
-  return (
-    <section className="flex flex-col gap-16">
-      <div className="flex flex-col items-center gap-6 text-center">
-        <span className="rounded-full border border-slate-700 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-slate-300">
-          Build Your Worlds
-        </span>
-        <h2 className="max-w-3xl text-balance text-4xl font-bold tracking-tight text-white sm:text-5xl">
-          Unleash your creativity and bring your tabletop game ideas to life with ease!
-        </h2>
-        <p className="max-w-2xl text-balance text-lg leading-relaxed text-slate-300">
-          Tabletop Creator is the all-in-one tool for designing boards, cards, quest posters, and more.
-        </p>
-      </div>
+  const navigate = useNavigate();
+  const { projects, createProject } = useProjects();
+  const [isDialogOpen, setDialogOpen] = useState(false);
 
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {features.map((feature) => (
-          <FeatureCard key={feature.title} title={feature.title} description={feature.description} />
-        ))}
-      </div>
-    </section>
+  const handleCreateProject = ({ name, initialItem }: { name: string; initialItem?: ItemInput }) => {
+    const project = createProject({ name, initialItem });
+    setDialogOpen(false);
+    navigate(`/projects/${project.id}`);
+  };
+
+  const handleOpenProject = (projectId: string) => {
+    navigate(`/projects/${projectId}`);
+  };
+
+  return (
+    <>
+      <section className="flex flex-col gap-12">
+        <div className="flex flex-col items-center gap-6 text-center">
+          <span className="rounded-full border border-slate-700 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-slate-300">
+            Build Your Worlds
+          </span>
+          <h2 className="max-w-3xl text-balance text-4xl font-bold tracking-tight text-white sm:text-5xl">
+            Unleash your creativity and bring your tabletop game ideas to life with ease!
+          </h2>
+          <p className="max-w-2xl text-balance text-lg leading-relaxed text-slate-300">
+            Tabletop Creator is the all-in-one tool for designing boards, cards, quest posters, and more.
+          </p>
+        </div>
+
+        <ProjectOverviewPanel
+          projects={projects}
+          onOpenProject={handleOpenProject}
+          onCreateProject={() => setDialogOpen(true)}
+        />
+      </section>
+
+      <NewProjectDialog open={isDialogOpen} onClose={() => setDialogOpen(false)} onCreate={handleCreateProject} />
+    </>
   );
 }
 

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import ImageAssetBrowser from '../components/ImageAssetBrowser';
+import NewItemDialog from '../components/NewItemDialog';
+import { AssetInput, ItemInput, Project } from '../context/ProjectContext';
+import { findProject, useProjects } from '../context/ProjectContext';
+
+function ProjectPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
+  const { projects, updateProjectName, addItemToProject, addAssetsToProject, removeAssetsFromProject } = useProjects();
+  const [isCollapsed, setCollapsed] = useState(false);
+  const [isEditingTitle, setEditingTitle] = useState(false);
+  const [titleValue, setTitleValue] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isItemDialogOpen, setItemDialogOpen] = useState(false);
+  const [isAssetBrowserOpen, setAssetBrowserOpen] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const project: Project | null = useMemo(() => {
+    if (!projectId) {
+      return null;
+    }
+    return findProject(projects, projectId);
+  }, [projects, projectId]);
+
+  useEffect(() => {
+    if (project) {
+      setTitleValue(project.name);
+    }
+  }, [project]);
+
+  useEffect(() => {
+    if (statusMessage) {
+      const timeout = setTimeout(() => setStatusMessage(null), 4000);
+      return () => clearTimeout(timeout);
+    }
+    return undefined;
+  }, [statusMessage]);
+
+  if (!project) {
+    return (
+      <section className="flex flex-col items-center justify-center gap-6 rounded-3xl border border-slate-800 bg-slate-900/40 p-12 text-center">
+        <h2 className="text-3xl font-semibold text-white">Project not found</h2>
+        <p className="max-w-md text-sm text-slate-300">
+          The project you are trying to open does not exist or may have been removed. Return to the dashboard to view your
+          projects or start a new one.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          className="rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+        >
+          Back to home
+        </button>
+      </section>
+    );
+  }
+
+  const filteredItems = project.items.filter((item) =>
+    item.name.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
+  const handleRename = () => {
+    const trimmed = titleValue.trim();
+    if (!trimmed || trimmed === project.name) {
+      setTitleValue(project.name);
+      setEditingTitle(false);
+      return;
+    }
+
+    updateProjectName(project.id, trimmed);
+    setEditingTitle(false);
+    setStatusMessage('Project name updated');
+  };
+
+  const handleAddItem = (item: ItemInput) => {
+    addItemToProject(project.id, item);
+    setStatusMessage(`${item.name} added to ${project.name}`);
+  };
+
+  const handleAddAssets = (assets: AssetInput[]) => {
+    addAssetsToProject(project.id, assets);
+    setStatusMessage(`${assets.length} asset${assets.length === 1 ? '' : 's'} added to the library`);
+  };
+
+  const handleRemoveAssets = (assetIds: string[]) => {
+    if (assetIds.length === 0) {
+      return;
+    }
+    removeAssetsFromProject(project.id, assetIds);
+    setStatusMessage(`${assetIds.length} asset${assetIds.length === 1 ? '' : 's'} deleted`);
+  };
+
+  const handleLocateAsset = (assetId: string) => {
+    const asset = project.assets.find((candidate) => candidate.id === assetId);
+    if (asset) {
+      setStatusMessage(`Coming soon: locate "${asset.name}" within your layouts.`);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 lg:flex-row">
+      <aside
+        className={`relative flex w-full flex-col rounded-3xl border border-slate-800 bg-slate-900/60 transition-all duration-300 lg:w-auto ${
+          isCollapsed ? 'lg:max-w-[5.5rem] lg:p-4' : 'lg:max-w-xs lg:p-6'
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => setCollapsed((prev) => !prev)}
+          className="absolute right-4 top-4 hidden h-9 w-9 items-center justify-center rounded-full border border-slate-700/70 text-slate-300 transition hover:border-emerald-500 hover:text-emerald-200 lg:flex"
+          aria-label={isCollapsed ? 'Expand action menu' : 'Collapse action menu'}
+        >
+          <svg viewBox="0 0 24 24" className={`h-4 w-4 transition-transform ${isCollapsed ? 'rotate-180' : ''}`} aria-hidden="true">
+            <path
+              fill="currentColor"
+              d="M10.5 6.5a.75.75 0 10-1.06 1.06L12.88 11l-3.44 3.44a.75.75 0 101.06 1.06l4-4a.75.75 0 000-1.06z"
+            />
+          </svg>
+        </button>
+
+        <div className={`flex-1 space-y-6 transition-opacity duration-200 ${isCollapsed ? 'opacity-0 pointer-events-none lg:hidden' : 'opacity-100'}`}>
+          <div className="flex flex-col gap-2 pr-10">
+            {isEditingTitle ? (
+              <input
+                value={titleValue}
+                onChange={(event) => setTitleValue(event.target.value)}
+                onBlur={handleRename}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    handleRename();
+                  } else if (event.key === 'Escape') {
+                    setTitleValue(project.name);
+                    setEditingTitle(false);
+                  }
+                }}
+                autoFocus
+                className="rounded-xl border border-emerald-500/70 bg-slate-950/80 px-4 py-2 text-lg font-semibold text-white outline-none focus:ring-2 focus:ring-emerald-500/40"
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setEditingTitle(true)}
+                className="text-left text-lg font-semibold text-white transition hover:text-emerald-200"
+              >
+                {project.name}
+              </button>
+            )}
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Action Menu</p>
+          </div>
+
+          <div className="space-y-4">
+            <label className="block text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+              Search project
+              <div className="mt-2 flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-950/70 px-3">
+                <svg viewBox="0 0 24 24" className="h-4 w-4 text-slate-500" aria-hidden="true">
+                  <path
+                    fill="currentColor"
+                    d="M10 4a6 6 0 014.62 9.8l4.29 4.29a.75.75 0 11-1.06 1.06l-4.29-4.29A6 6 0 1110 4zm0 1.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z"
+                  />
+                </svg>
+                <input
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="Search items, assets, notes..."
+                  className="w-full bg-transparent py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none"
+                  type="search"
+                />
+              </div>
+            </label>
+
+            <button
+              type="button"
+              onClick={() => setAssetBrowserOpen(true)}
+              className="flex w-full items-center justify-between rounded-2xl border border-slate-800/80 bg-slate-950/60 px-4 py-3 text-left text-sm font-semibold text-slate-200 transition hover:border-emerald-500/70 hover:text-emerald-100"
+            >
+              <span>Image Library</span>
+              <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-200">
+                {project.assets.length}
+              </span>
+            </button>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Items</p>
+              <button
+                type="button"
+                onClick={() => setItemDialogOpen(true)}
+                className="flex h-8 w-8 items-center justify-center rounded-md border border-slate-700/70 text-lg font-semibold text-slate-200 transition hover:border-emerald-500 hover:text-emerald-200"
+                aria-label="Add item"
+              >
+                +
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              {filteredItems.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-slate-700/70 bg-slate-950/60 px-4 py-6 text-center text-xs text-slate-400">
+                  No items match your search yet.
+                </p>
+              ) : (
+                filteredItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className="rounded-2xl border border-slate-800/80 bg-slate-950/70 px-4 py-4 text-sm text-slate-200 shadow-lg shadow-black/20"
+                  >
+                    <p className="font-semibold text-white">{item.name}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.3em] text-slate-500">{item.type}</p>
+                    <p className="mt-2 text-xs text-slate-400">{item.variant}</p>
+                    {item.customDetails && (
+                      <p className="mt-2 text-xs text-slate-500">{item.customDetails}</p>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className={`hidden flex-1 flex-col items-center gap-8 py-12 ${isCollapsed ? 'lg:flex' : 'lg:hidden'}`}>
+          <button
+            type="button"
+            onClick={() => setEditingTitle(true)}
+            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-700/70 text-white transition hover:border-emerald-500 hover:text-emerald-200"
+            title="Rename project"
+          >
+            ✎
+          </button>
+          <button
+            type="button"
+            onClick={() => setAssetBrowserOpen(true)}
+            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-700/70 text-white transition hover:border-emerald-500 hover:text-emerald-200"
+            title="Image library"
+          >
+            🖼️
+          </button>
+          <button
+            type="button"
+            onClick={() => setItemDialogOpen(true)}
+            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-700/70 text-white transition hover:border-emerald-500 hover:text-emerald-200"
+            title="Add item"
+          >
+            +
+          </button>
+        </div>
+      </aside>
+
+      <section className="flex-1 space-y-6">
+        {statusMessage && (
+          <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+            {statusMessage}
+          </div>
+        )}
+
+        <div className="rounded-3xl border border-slate-800 bg-slate-900/40 p-8">
+          <h2 className="text-2xl font-semibold text-white">Workspace</h2>
+          <p className="mt-3 max-w-2xl text-sm text-slate-300">
+            Your items appear here as you build them out. Use the action menu to browse assets, add new components, and manage your
+            project details. Drag-and-drop editing and placement tools will arrive in future updates.
+          </p>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {project.items.map((item) => (
+              <div key={item.id} className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-4">
+                <p className="text-sm font-semibold text-white">{item.name}</p>
+                <p className="mt-1 text-xs uppercase tracking-[0.3em] text-slate-500">{item.type}</p>
+                <p className="mt-2 text-xs text-slate-400">{item.variant}</p>
+                {item.customDetails && <p className="mt-2 text-xs text-slate-500">Custom: {item.customDetails}</p>}
+              </div>
+            ))}
+            {project.items.length === 0 && (
+              <div className="col-span-full flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-700/70 bg-slate-950/60 p-12 text-center">
+                <p className="text-lg font-semibold text-white">No items yet</p>
+                <p className="mt-2 max-w-sm text-sm text-slate-400">
+                  Add your first board, card deck, or poster using the action menu on the left.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setItemDialogOpen(true)}
+                  className="mt-4 rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+                >
+                  Add an item
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-slate-800 bg-slate-900/40 p-8">
+          <h3 className="text-xl font-semibold text-white">Project Activity</h3>
+          <p className="mt-2 text-sm text-slate-400">
+            Keep track of asset uploads, layout tweaks, and collaborative notes. Future iterations will surface version history and
+            assignable tasks.
+          </p>
+          <ul className="mt-6 space-y-3 text-sm text-slate-300">
+            <li className="rounded-2xl border border-slate-800/70 bg-slate-950/60 px-4 py-3">
+              <span className="font-semibold text-white">{project.name}</span> is ready for exploration. Start adding details
+              to each component.
+            </li>
+            <li className="rounded-2xl border border-slate-800/70 bg-slate-950/60 px-4 py-3">
+              Upload reference art or icons to the image library to keep inspiration close at hand.
+            </li>
+          </ul>
+          <div className="mt-6 text-xs text-slate-500">
+            Looking for something else? <Link to="/" className="text-emerald-300 transition hover:text-emerald-200">Return to the dashboard</Link> to switch projects.
+          </div>
+        </div>
+      </section>
+
+      <NewItemDialog open={isItemDialogOpen} onClose={() => setItemDialogOpen(false)} onSubmit={handleAddItem} />
+
+      <ImageAssetBrowser
+        open={isAssetBrowserOpen}
+        assets={project.assets}
+        onClose={() => setAssetBrowserOpen(false)}
+        onAddAssets={handleAddAssets}
+        onRemoveAssets={handleRemoveAssets}
+        onLocateAsset={handleLocateAsset}
+      />
+    </div>
+  );
+}
+
+export default ProjectPage;


### PR DESCRIPTION
## Summary
- replace the home page feature cards with a project overview and guided creation dialog
- introduce shared project state with routing to a dedicated project workspace page
- build an action menu, asset library browser, and item management tools for each project

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d94f74c76c832f8b904781ae11db49