### PR TITLE
Add theme management and update UI styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,22 @@
 import { Route, Routes } from 'react-router-dom';
 
+import ThemeSwitcher from './components/ThemeSwitcher';
 import Home from './pages/Home';
 import ProjectPage from './pages/ProjectPage';
 
 function App() {
   return (
-    <div className="min-h-screen bg-slate-950 font-sans text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/70 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-6 py-6 text-center sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-2xl font-semibold tracking-tight text-slate-100 sm:text-3xl">
+    <div className="min-h-screen bg-background font-sans text-text-primary">
+      <header className="border-b border-border bg-surface/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 py-6 text-center sm:flex-row sm:items-center sm:justify-between">
+          <h1 className="text-2xl font-semibold tracking-tight text-text-primary sm:text-3xl">
             Tabletop Creator – Your Friendly Game Design Companion
           </h1>
-          <nav className="text-sm text-slate-300">
-            <span className="rounded-full border border-slate-700 px-3 py-1 font-medium uppercase tracking-wide text-slate-300">
+          <nav className="flex flex-col items-center justify-end gap-2 text-sm text-text-secondary sm:flex-row">
+            <span className="rounded-full border border-border/70 px-3 py-1 font-medium uppercase tracking-wide text-text-secondary">
               Starter Layout
             </span>
+            <ThemeSwitcher />
           </nav>
         </div>
       </header>
@@ -26,8 +28,8 @@ function App() {
         </Routes>
       </main>
 
-      <footer className="border-t border-slate-800 bg-slate-900/70">
-        <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-6 py-6 text-center text-sm text-slate-400 sm:flex-row sm:justify-between">
+      <footer className="border-t border-border bg-surface/80">
+        <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-6 py-6 text-center text-sm text-text-muted sm:flex-row sm:justify-between">
           <p>&copy; {new Date().getFullYear()} Tabletop Creator. All rights reserved.</p>
           <p className="text-xs sm:text-sm">Crafted with Vite, React, TypeScript, and Tailwind CSS.</p>
         </div>

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -5,22 +5,16 @@ type FeatureCardProps = {
 
 function FeatureCard({ title, description }: FeatureCardProps) {
   return (
-    <article className="group rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40 transition hover:-translate-y-1 hover:border-slate-700 hover:bg-slate-900/80">
-      <h3 className="text-xl font-semibold text-white transition group-hover:text-emerald-300">
+    <article className="group rounded-2xl border border-border bg-surface-muted/60 p-6 shadow-lg shadow-black/40 transition hover:-translate-y-1 hover:border-border/70 hover:bg-surface-muted/80">
+      <h3 className="text-xl font-semibold text-text-primary transition group-hover:text-accent/80">
         {title}
       </h3>
-      <p className="mt-3 text-sm leading-relaxed text-slate-300">
+      <p className="mt-3 text-sm leading-relaxed text-text-secondary">
         {description}
       </p>
-      <div className="mt-6 flex items-center gap-2 text-sm font-medium text-emerald-300">
+      <div className="mt-6 flex items-center gap-2 text-sm font-medium text-accent/70">
         <span>Coming soon</span>
-        <svg
-          aria-hidden="true"
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-4 w-4"
-          viewBox="0 0 16 16"
-          fill="currentColor"
-        >
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
           <path d="M4.5 3.5a.75.75 0 0 1 .75-.75h5a.75.75 0 0 1 0 1.5h-3.19l5.72 5.72a.75.75 0 1 1-1.06 1.06L6 5.31v3.19a.75.75 0 0 1-1.5 0z" />
         </svg>
       </div>

--- a/src/components/ImageAssetBrowser.tsx
+++ b/src/components/ImageAssetBrowser.tsx
@@ -50,12 +50,12 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-6 backdrop-blur">
-      <div className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-slate-800 bg-slate-950/95 shadow-2xl shadow-black/60">
-        <div className="flex items-center justify-between border-b border-slate-800 px-8 py-6">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/70 p-6 backdrop-blur">
+      <div className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60">
+        <div className="flex items-center justify-between border-b border-border/70 px-8 py-6">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300/80">Image Library</p>
-            <h2 className="mt-1 text-xl font-semibold text-white">Manage your project visuals</h2>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">Image Library</p>
+            <h2 className="mt-1 text-xl font-semibold text-text-primary">Manage your project visuals</h2>
           </div>
           <div className="flex items-center gap-2">
             <button
@@ -66,7 +66,7 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
                 }
               }}
               disabled={selectedAssets.length !== 1}
-              className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold text-slate-300 transition disabled:cursor-not-allowed disabled:opacity-50 hover:border-emerald-500 hover:text-emerald-200"
+              className="rounded-full border border-border/70 px-4 py-2 text-xs font-semibold text-text-secondary transition disabled:cursor-not-allowed disabled:opacity-50 hover:border-accent hover:text-accent/80"
             >
               Locate usage
             </button>
@@ -78,14 +78,14 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
             >
               Delete selected
             </button>
-            <label className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-emerald-500 px-4 py-2 text-xs font-semibold text-slate-950 transition hover:bg-emerald-400">
+            <label className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-accent px-4 py-2 text-xs font-semibold text-accent-contrast transition hover:bg-accent-strong">
               <input type="file" accept="image/*" multiple className="hidden" onChange={handleFileChange} />
               Add images
             </label>
             <button
               type="button"
               onClick={clearStateAndClose}
-              className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-700/70 text-slate-300 transition hover:border-slate-500 hover:text-white"
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-border/70 text-text-secondary transition hover:border-accent hover:text-text-primary"
               aria-label="Close image library"
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
@@ -101,9 +101,9 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
         <div className="flex flex-1 overflow-hidden">
           <div className="flex-1 overflow-y-auto px-8 py-6">
             {assets.length === 0 ? (
-              <div className="flex h-full flex-col items-center justify-center rounded-2xl border border-dashed border-slate-700/70 bg-slate-900/50 p-12 text-center">
-                <p className="text-lg font-semibold text-slate-200">No images yet</p>
-                <p className="mt-2 max-w-md text-sm text-slate-400">
+              <div className="flex h-full flex-col items-center justify-center rounded-2xl border border-dashed border-border/70 bg-surface-muted/50 p-12 text-center">
+                <p className="text-lg font-semibold text-text-secondary">No images yet</p>
+                <p className="mt-2 max-w-md text-sm text-text-muted">
                   Use the "Add images" button to import concept art, icons, or reference boards for this project.
                 </p>
               </div>
@@ -115,13 +115,13 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
                     <div
                       key={asset.id}
                       className={`group relative overflow-hidden rounded-2xl border transition ${
-                        selected ? 'border-emerald-500/70' : 'border-slate-800/80'
+                        selected ? 'border-accent/70' : 'border-border/80'
                       }`}
                     >
                       <button
                         type="button"
                         onClick={() => setPreviewAssetId(asset.id)}
-                        className="relative block h-40 w-full overflow-hidden bg-slate-900/80"
+                        className="relative block h-40 w-full overflow-hidden bg-surface-muted/80"
                       >
                         <img
                           src={asset.url}
@@ -129,8 +129,8 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
                           className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
                         />
                       </button>
-                      <div className="flex items-center justify-between gap-2 border-t border-slate-800/80 bg-slate-900/80 px-3 py-3">
-                        <p className="truncate text-xs font-semibold text-slate-200" title={asset.name}>
+                      <div className="flex items-center justify-between gap-2 border-t border-border/80 bg-surface-muted/80 px-3 py-3">
+                        <p className="truncate text-xs font-semibold text-text-secondary" title={asset.name}>
                           {asset.name}
                         </p>
                         <button
@@ -138,8 +138,8 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
                           onClick={() => toggleSelected(asset.id)}
                           className={`flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold transition ${
                             selected
-                              ? 'border-emerald-500/70 bg-emerald-500/20 text-emerald-200'
-                              : 'border-slate-700/70 text-slate-300 hover:border-emerald-500 hover:text-emerald-200'
+                              ? 'border-accent/70 bg-accent/20 text-accent/80'
+                              : 'border-border/70 text-text-secondary hover:border-accent hover:text-accent/80'
                           }`}
                         >
                           {selected ? '✓' : '+'}
@@ -152,18 +152,18 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
             )}
           </div>
 
-          <div className="hidden w-64 border-l border-slate-800/80 bg-slate-950/90 p-6 lg:block">
-            <h3 className="text-sm font-semibold text-slate-200">Preview</h3>
+          <div className="hidden w-64 border-l border-border/80 bg-surface-elevated/90 p-6 lg:block">
+            <h3 className="text-sm font-semibold text-text-secondary">Preview</h3>
             {previewAsset ? (
               <div className="mt-4 space-y-3">
-                <div className="overflow-hidden rounded-xl border border-slate-800/80">
+                <div className="overflow-hidden rounded-xl border border-border/80">
                   <img src={previewAsset.url} alt={previewAsset.name} className="w-full" />
                 </div>
-                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Title</p>
-                <p className="text-sm font-semibold text-white">{previewAsset.name}</p>
+                <p className="text-xs uppercase tracking-[0.3em] text-text-muted">Title</p>
+                <p className="text-sm font-semibold text-text-primary">{previewAsset.name}</p>
               </div>
             ) : (
-              <p className="mt-4 text-xs text-slate-500">Select an asset to see a larger preview.</p>
+              <p className="mt-4 text-xs text-text-muted">Select an asset to see a larger preview.</p>
             )}
           </div>
         </div>

--- a/src/components/NewItemDialog.tsx
+++ b/src/components/NewItemDialog.tsx
@@ -63,17 +63,17 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur">
-      <div className="w-full max-w-2xl rounded-3xl border border-slate-800 bg-slate-950/95 shadow-2xl shadow-black/60">
-        <div className="flex items-center justify-between border-b border-slate-800 px-6 py-5">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/70 p-4 backdrop-blur">
+      <div className="w-full max-w-2xl rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60">
+        <div className="flex items-center justify-between border-b border-border/70 px-6 py-5">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300/80">New Item</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">Add to this project</h2>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">New Item</p>
+            <h2 className="mt-2 text-xl font-semibold text-text-primary">Add to this project</h2>
           </div>
           <button
             type="button"
             onClick={handleClose}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-700/70 text-slate-300 transition hover:border-slate-500 hover:text-white"
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-border/70 text-text-secondary transition hover:border-accent hover:text-text-primary"
             aria-label="Close"
           >
             <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
@@ -86,13 +86,13 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6 px-6 py-5">
-          <label className="block text-sm font-semibold text-slate-200">
+          <label className="block text-sm font-semibold text-text-secondary">
             Item title
             <input
               value={formState.name}
               onChange={(event) => setFormState((state) => ({ ...state, name: event.target.value }))}
               placeholder="e.g. Quest Log Poster"
-              className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-2 text-base text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+              className="mt-2 w-full rounded-xl border border-border bg-surface-muted/60 px-4 py-2 text-base text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
               required
             />
           </label>
@@ -112,18 +112,18 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
                 }
                 className={`rounded-2xl border px-4 py-4 text-left transition ${
                   formState.itemType === type.id
-                    ? 'border-emerald-500/70 bg-emerald-500/10 text-emerald-100'
-                    : 'border-slate-800/80 bg-slate-950/50 text-slate-300 hover:border-slate-600 hover:bg-slate-900'
+                    ? 'border-accent/70 bg-accent/10 text-text-primary'
+                    : 'border-border/80 bg-surface/50 text-text-secondary hover:border-border/60 hover:bg-surface-muted'
                 }`}
               >
-                <p className="text-sm font-semibold">{type.name}</p>
-                <p className="mt-1 text-xs text-slate-400">{type.description}</p>
+                <p className="text-sm font-semibold text-text-primary">{type.name}</p>
+                <p className="mt-1 text-xs text-text-muted">{type.description}</p>
               </button>
             ))}
           </div>
 
-          <div className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Format</p>
+          <div className="rounded-2xl border border-border/80 bg-surface/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">Format</p>
             <div className="mt-3 flex flex-wrap gap-2">
               {typeDefinition.variants.map((variant) => (
                 <button
@@ -132,8 +132,8 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
                   onClick={() => setFormState((state) => ({ ...state, variant }))}
                   className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
                     formState.variant === variant
-                      ? 'bg-emerald-500 text-slate-950'
-                      : 'bg-slate-900 text-slate-300 hover:bg-slate-800'
+                      ? 'bg-accent text-accent-contrast'
+                      : 'bg-surface-muted text-text-secondary hover:bg-surface-muted/80'
                   }`}
                 >
                   {variant}
@@ -142,31 +142,31 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
             </div>
 
             {showCustomField && (
-              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
                 Custom details
                 <input
                   value={formState.customDetails}
                   onChange={(event) => setFormState((state) => ({ ...state, customDetails: event.target.value }))}
                   placeholder="Add size or notes"
-                  className="mt-2 w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+                  className="mt-2 w-full rounded-lg border border-border bg-surface-muted/60 px-3 py-2 text-sm text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
                 />
               </label>
             )}
           </div>
 
-          <div className="flex flex-col gap-3 border-t border-slate-800/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs text-slate-400">You can refine this item's layout once it's added.</p>
+          <div className="flex flex-col gap-3 border-t border-border/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-text-muted">You can refine this item's layout once it's added.</p>
             <div className="flex gap-3">
               <button
                 type="button"
                 onClick={handleClose}
-                className="rounded-full border border-slate-700/70 px-5 py-2 text-sm font-semibold text-slate-300 transition hover:border-slate-500 hover:text-white"
+                className="rounded-full border border-border/70 px-5 py-2 text-sm font-semibold text-text-secondary transition hover:border-accent hover:text-text-primary"
               >
                 Cancel
               </button>
               <button
                 type="submit"
-                className="rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+                className="rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast transition hover:bg-accent-strong"
               >
                 Add item
               </button>

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -77,17 +77,17 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur">
-      <div className="w-full max-w-3xl rounded-3xl border border-slate-800 bg-slate-950/95 shadow-2xl shadow-black/60">
-        <div className="flex items-center justify-between border-b border-slate-800 px-8 py-6">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/70 p-4 backdrop-blur">
+      <div className="w-full max-w-3xl rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60">
+        <div className="flex items-center justify-between border-b border-border/70 px-8 py-6">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-300/80">New Project</p>
-            <h2 className="mt-2 text-2xl font-semibold text-white">Create a tabletop adventure workspace</h2>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">New Project</p>
+            <h2 className="mt-2 text-2xl font-semibold text-text-primary">Create a tabletop adventure workspace</h2>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-700/70 text-slate-300 transition hover:border-slate-500 hover:text-white"
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-border/70 text-text-secondary transition hover:border-accent hover:text-text-primary"
             aria-label="Close"
           >
             <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
@@ -101,30 +101,30 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
 
         <form onSubmit={handleSubmit} className="grid gap-8 px-8 py-6 sm:grid-cols-2">
           <div className="space-y-4">
-            <label className="block text-sm font-semibold text-slate-200">
+            <label className="block text-sm font-semibold text-text-secondary">
               Project name
               <input
                 value={formState.name}
                 onChange={(event) => setFormState((state) => ({ ...state, name: event.target.value }))}
                 placeholder="e.g. Clockwork Isles Campaign"
-                className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-2 text-base text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+                className="mt-2 w-full rounded-xl border border-border bg-surface-muted/60 px-4 py-2 text-base text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
                 required
               />
             </label>
 
-            <div className="rounded-2xl border border-slate-800/80 bg-slate-900/40 p-4">
-              <p className="text-sm font-semibold text-slate-200">First item</p>
-              <p className="mt-1 text-xs text-slate-400">
+            <div className="rounded-2xl border border-border/80 bg-surface-muted/40 p-4">
+              <p className="text-sm font-semibold text-text-secondary">First item</p>
+              <p className="mt-1 text-xs text-text-muted">
                 Give your project a head start with the first board, deck, or poster.
               </p>
 
-              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
                 Item title
                 <input
                   value={formState.itemName}
                   onChange={(event) => setFormState((state) => ({ ...state, itemName: event.target.value }))}
                   placeholder="e.g. Encounter Deck"
-                  className="mt-2 w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+                  className="mt-2 w-full rounded-lg border border-border bg-surface-muted/60 px-3 py-2 text-sm text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
                 />
               </label>
             </div>
@@ -146,18 +146,18 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
                   }
                   className={`rounded-2xl border px-4 py-4 text-left transition ${
                     formState.itemType === type.id
-                      ? 'border-emerald-500/70 bg-emerald-500/10 text-emerald-100'
-                      : 'border-slate-800/80 bg-slate-950/50 text-slate-300 hover:border-slate-600 hover:bg-slate-900'
+                      ? 'border-accent/70 bg-accent/10 text-text-primary'
+                      : 'border-border/80 bg-surface/50 text-text-secondary hover:border-border/60 hover:bg-surface-muted'
                   }`}
                 >
-                  <p className="text-sm font-semibold">{type.name}</p>
-                  <p className="mt-1 text-xs text-slate-400">{type.description}</p>
+                  <p className="text-sm font-semibold text-text-primary">{type.name}</p>
+                  <p className="mt-1 text-xs text-text-muted">{type.description}</p>
                 </button>
               ))}
             </div>
 
-            <div className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Format</p>
+            <div className="rounded-2xl border border-border/80 bg-surface/60 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">Format</p>
               <div className="mt-3 flex flex-wrap gap-2">
                 {typeDefinition.variants.map((variant) => (
                   <button
@@ -166,8 +166,8 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
                     onClick={() => setFormState((state) => ({ ...state, variant }))}
                     className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
                       formState.variant === variant
-                        ? 'bg-emerald-500 text-slate-950'
-                        : 'bg-slate-900 text-slate-300 hover:bg-slate-800'
+                        ? 'bg-accent text-accent-contrast'
+                        : 'bg-surface-muted text-text-secondary hover:bg-surface-muted/80'
                     }`}
                   >
                     {variant}
@@ -176,32 +176,32 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
               </div>
 
               {showCustomField && (
-                <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
                   Custom details
                   <input
                     value={formState.customDetails}
                     onChange={(event) => setFormState((state) => ({ ...state, customDetails: event.target.value }))}
                     placeholder="Add size or notes"
-                    className="mt-2 w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-white outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/40"
+                    className="mt-2 w-full rounded-lg border border-border bg-surface-muted/60 px-3 py-2 text-sm text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
                   />
                 </label>
               )}
             </div>
           </div>
 
-          <div className="sm:col-span-2 flex flex-col gap-3 border-t border-slate-800/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs text-slate-400">You can add more items or assets after your project is created.</p>
+          <div className="sm:col-span-2 flex flex-col gap-3 border-t border-border/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-text-muted">You can add more items or assets after your project is created.</p>
             <div className="flex gap-3">
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-full border border-slate-700/70 px-5 py-2 text-sm font-semibold text-slate-300 transition hover:border-slate-500 hover:text-white"
+                className="rounded-full border border-border/70 px-5 py-2 text-sm font-semibold text-text-secondary transition hover:border-accent hover:text-text-primary"
               >
                 Cancel
               </button>
               <button
                 type="submit"
-                className="rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+                className="rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast transition hover:bg-accent-strong"
               >
                 Create project
               </button>

--- a/src/components/ProjectOverviewPanel.tsx
+++ b/src/components/ProjectOverviewPanel.tsx
@@ -8,14 +8,14 @@ interface ProjectOverviewPanelProps {
 
 function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject }: ProjectOverviewPanelProps) {
   return (
-    <section className="rounded-3xl border border-slate-800 bg-slate-900/60 shadow-2xl shadow-slate-950/40">
+    <section className="rounded-3xl border border-border bg-surface-muted/60 shadow-2xl shadow-black/40">
       <div className="flex flex-col gap-6 p-8 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300/80">Project Overview</p>
-          <h2 className="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent/70">Project Overview</p>
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-text-primary sm:text-4xl">
             Continue crafting your tabletop worlds
           </h2>
-          <p className="mt-3 max-w-2xl text-sm text-slate-300 sm:text-base">
+          <p className="mt-3 max-w-2xl text-sm text-text-secondary sm:text-base">
             Access your active projects or start something brand new. Each project keeps boards, decks, posters, and assets neatly
             organized for fast iteration.
           </p>
@@ -23,23 +23,23 @@ function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject }: Proj
         <button
           type="button"
           onClick={onCreateProject}
-          className="inline-flex items-center justify-center rounded-full border border-emerald-500/60 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:bg-emerald-400/20 hover:text-white"
+          className="inline-flex items-center justify-center rounded-full border border-accent/60 bg-accent/10 px-4 py-2 text-sm font-semibold text-accent/80 transition hover:bg-accent-strong/20 hover:text-text-primary"
         >
           New Project +
         </button>
       </div>
 
-      <div className="border-t border-slate-800/60" />
+      <div className="border-t border-border/60" />
 
       <div className="grid gap-6 p-8 sm:grid-cols-2 lg:grid-cols-3">
         {projects.length === 0 ? (
-          <div className="col-span-full flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-700/70 bg-slate-900/40 px-6 py-12 text-center">
-            <p className="text-lg font-semibold text-slate-200">No projects yet</p>
-            <p className="mt-2 max-w-sm text-sm text-slate-400">When you create your first project it will appear here for quick access.</p>
+          <div className="col-span-full flex flex-col items-center justify-center rounded-2xl border border-dashed border-border/70 bg-surface-muted/40 px-6 py-12 text-center">
+            <p className="text-lg font-semibold text-text-secondary">No projects yet</p>
+            <p className="mt-2 max-w-sm text-sm text-text-muted">When you create your first project it will appear here for quick access.</p>
             <button
               type="button"
               onClick={onCreateProject}
-              className="mt-6 inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+              className="mt-6 inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast transition hover:bg-accent-strong"
             >
               Start your first project
             </button>
@@ -50,16 +50,16 @@ function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject }: Proj
               key={project.id}
               type="button"
               onClick={() => onOpenProject(project.id)}
-              className="group flex flex-col rounded-2xl border border-slate-800/80 bg-slate-950/60 p-6 text-left shadow-lg shadow-black/30 transition hover:-translate-y-1 hover:border-emerald-500/70 hover:bg-slate-900/80 hover:shadow-emerald-500/20"
+              className="group flex flex-col rounded-2xl border border-border/80 bg-surface/60 p-6 text-left shadow-lg shadow-black/30 transition hover:-translate-y-1 hover:border-accent/70 hover:bg-surface-muted/80 hover:shadow-accent/30"
             >
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Project</p>
-                  <h3 className="mt-2 text-xl font-semibold text-white transition group-hover:text-emerald-200">
+                  <p className="text-xs uppercase tracking-[0.25em] text-text-muted">Project</p>
+                  <h3 className="mt-2 text-xl font-semibold text-text-primary transition group-hover:text-accent/80">
                     {project.name}
                   </h3>
                 </div>
-                <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-200 transition group-hover:bg-emerald-400/20">
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-accent/10 text-accent/80 transition group-hover:bg-accent-strong/20">
                   <svg
                     aria-hidden="true"
                     viewBox="0 0 24 24"
@@ -72,21 +72,21 @@ function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject }: Proj
                   </svg>
                 </span>
               </div>
-              <p className="mt-4 text-sm text-slate-400">
+              <p className="mt-4 text-sm text-text-muted">
                 {project.items.length > 0
                   ? `${project.items.length} item${project.items.length === 1 ? '' : 's'} ready to refine`
                   : 'No items added yet — jump in to get started.'}
               </p>
               {project.items.length > 0 && (
-                <ul className="mt-4 space-y-2 text-sm text-slate-300">
+                <ul className="mt-4 space-y-2 text-sm text-text-secondary">
                   {project.items.slice(0, 3).map((item) => (
                     <li key={item.id} className="flex items-center gap-2">
-                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" aria-hidden />
+                      <span className="h-1.5 w-1.5 rounded-full bg-highlight" aria-hidden />
                       <span>{item.name}</span>
                     </li>
                   ))}
                   {project.items.length > 3 && (
-                    <li className="text-xs uppercase tracking-widest text-slate-500">
+                    <li className="text-xs uppercase tracking-widest text-text-muted">
                       +{project.items.length - 3} more
                     </li>
                   )}

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,30 @@
+import { ChangeEvent } from 'react';
+
+import { useTheme } from '../context/ThemeContext';
+
+function ThemeSwitcher() {
+  const { themeId, availableThemes, setThemeId } = useTheme();
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setThemeId(event.target.value);
+  };
+
+  return (
+    <label className="flex items-center gap-2 rounded-full border border-border/60 bg-surface-muted/60 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
+      Theme
+      <select
+        value={themeId}
+        onChange={handleChange}
+        className="rounded-full border border-border/60 bg-surface/80 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.25em] text-text-secondary outline-none transition focus:border-accent focus:text-text-primary"
+      >
+        {availableThemes.map((theme) => (
+          <option key={theme.id} value={theme.id} className="text-base text-text-primary">
+            {theme.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export default ThemeSwitcher;

--- a/src/constants/themes.ts
+++ b/src/constants/themes.ts
@@ -1,0 +1,82 @@
+export type ThemeColorScheme = 'light' | 'dark';
+
+export interface ThemeDefinition {
+  id: string;
+  label: string;
+  colorScheme: ThemeColorScheme;
+  tokens: Record<string, string>;
+}
+
+export const THEME_PRESETS: ThemeDefinition[] = [
+  {
+    id: 'midnight',
+    label: 'Midnight Workshop',
+    colorScheme: 'dark',
+    tokens: {
+      '--color-background': '#020617',
+      '--color-surface': '#0f172a',
+      '--color-surface-muted': '#111c30',
+      '--color-surface-elevated': '#1e293b',
+      '--color-border': '#1f2937',
+      '--color-border-strong': '#334155',
+      '--color-text-primary': '#f8fafc',
+      '--color-text-secondary': '#e2e8f0',
+      '--color-text-muted': '#94a3b8',
+      '--color-text-inverse': '#020617',
+      '--color-accent': '#10b981',
+      '--color-accent-strong': '#34d399',
+      '--color-accent-contrast': '#022c22',
+      '--color-overlay': '#020617',
+      '--color-ring': '#22c55e',
+      '--color-highlight': '#34d399',
+    },
+  },
+  {
+    id: 'parchment',
+    label: 'Parchment Light',
+    colorScheme: 'light',
+    tokens: {
+      '--color-background': '#fdfaf4',
+      '--color-surface': '#f8f1e8',
+      '--color-surface-muted': '#f0e6d8',
+      '--color-surface-elevated': '#ffffff',
+      '--color-border': '#e2d5c3',
+      '--color-border-strong': '#d2bda0',
+      '--color-text-primary': '#3b2f2f',
+      '--color-text-secondary': '#57453f',
+      '--color-text-muted': '#87746b',
+      '--color-text-inverse': '#ffffff',
+      '--color-accent': '#c47f3f',
+      '--color-accent-strong': '#de9248',
+      '--color-accent-contrast': '#3b2007',
+      '--color-overlay': '#1a120c',
+      '--color-ring': '#de9248',
+      '--color-highlight': '#f3a261',
+    },
+  },
+  {
+    id: 'aurora',
+    label: 'Aurora Green',
+    colorScheme: 'dark',
+    tokens: {
+      '--color-background': '#041418',
+      '--color-surface': '#062026',
+      '--color-surface-muted': '#072c35',
+      '--color-surface-elevated': '#0c3a44',
+      '--color-border': '#0f4a55',
+      '--color-border-strong': '#145d6a',
+      '--color-text-primary': '#f1fff7',
+      '--color-text-secondary': '#cfeee1',
+      '--color-text-muted': '#9bcbb7',
+      '--color-text-inverse': '#032021',
+      '--color-accent': '#4fd1c5',
+      '--color-accent-strong': '#5eead4',
+      '--color-accent-contrast': '#022c22',
+      '--color-overlay': '#011014',
+      '--color-ring': '#5eead4',
+      '--color-highlight': '#8be9dd',
+    },
+  },
+];
+
+export const DEFAULT_THEME_ID = THEME_PRESETS[0].id;

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,80 @@
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+
+import { DEFAULT_THEME_ID, ThemeDefinition, THEME_PRESETS } from '../constants/themes';
+
+interface ThemeContextValue {
+  theme: ThemeDefinition;
+  themeId: string;
+  availableThemes: ThemeDefinition[];
+  setThemeId: (themeId: string) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'tabletop-creator-theme';
+
+const hexToRgbString = (hex: string): string => {
+  if (hex.startsWith('rgb')) {
+    return hex.replace(/rgb\(|\)/g, '').replace(/\s+/g, ' ').trim();
+  }
+
+  const normalized = hex.replace('#', '');
+  if (normalized.length !== 6) {
+    return hex;
+  }
+
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  return `${r} ${g} ${b}`;
+};
+
+const applyTheme = (theme: ThemeDefinition) => {
+  const root = document.documentElement;
+  root.dataset.theme = theme.id;
+  root.style.colorScheme = theme.colorScheme;
+
+  Object.entries(theme.tokens).forEach(([token, value]) => {
+    root.style.setProperty(token, hexToRgbString(value));
+  });
+};
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [themeId, setThemeId] = useState(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_THEME_ID;
+    }
+
+    return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_THEME_ID;
+  });
+
+  useEffect(() => {
+    const activeTheme = THEME_PRESETS.find((candidate) => candidate.id === themeId) ?? THEME_PRESETS[0];
+    applyTheme(activeTheme);
+    localStorage.setItem(STORAGE_KEY, activeTheme.id);
+  }, [themeId]);
+
+  const value = useMemo<ThemeContextValue>(() => {
+    const theme = THEME_PRESETS.find((candidate) => candidate.id === themeId) ?? THEME_PRESETS[0];
+    return {
+      theme,
+      themeId: theme.id,
+      availableThemes: THEME_PRESETS,
+      setThemeId,
+    };
+  }, [themeId]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,14 +4,17 @@ import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
 import { ProjectProvider } from './context/ProjectContext';
+import { ThemeProvider } from './context/ThemeContext';
 import './styles/tailwind.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <ProjectProvider>
-        <App />
-      </ProjectProvider>
+      <ThemeProvider>
+        <ProjectProvider>
+          <App />
+        </ProjectProvider>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,13 +25,13 @@ function Home() {
     <>
       <section className="flex flex-col gap-12">
         <div className="flex flex-col items-center gap-6 text-center">
-          <span className="rounded-full border border-slate-700 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-slate-300">
+          <span className="rounded-full border border-border/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-text-secondary">
             Build Your Worlds
           </span>
-          <h2 className="max-w-3xl text-balance text-4xl font-bold tracking-tight text-white sm:text-5xl">
+          <h2 className="max-w-3xl text-balance text-4xl font-bold tracking-tight text-text-primary sm:text-5xl">
             Unleash your creativity and bring your tabletop game ideas to life with ease!
           </h2>
-          <p className="max-w-2xl text-balance text-lg leading-relaxed text-slate-300">
+          <p className="max-w-2xl text-balance text-lg leading-relaxed text-text-secondary">
             Tabletop Creator is the all-in-one tool for designing boards, cards, quest posters, and more.
           </p>
         </div>

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -41,16 +41,16 @@ function ProjectPage() {
 
   if (!project) {
     return (
-      <section className="flex flex-col items-center justify-center gap-6 rounded-3xl border border-slate-800 bg-slate-900/40 p-12 text-center">
-        <h2 className="text-3xl font-semibold text-white">Project not found</h2>
-        <p className="max-w-md text-sm text-slate-300">
+      <section className="flex flex-col items-center justify-center gap-6 rounded-3xl border border-border bg-surface-muted/40 p-12 text-center">
+        <h2 className="text-3xl font-semibold text-text-primary">Project not found</h2>
+        <p className="max-w-md text-sm text-text-secondary">
           The project you are trying to open does not exist or may have been removed. Return to the dashboard to view your
           projects or start a new one.
         </p>
         <button
           type="button"
           onClick={() => navigate('/')}
-          className="rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+          className="rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast transition hover:bg-accent-strong"
         >
           Back to home
         </button>
@@ -103,14 +103,14 @@ function ProjectPage() {
   return (
     <div className="flex flex-col gap-6 lg:flex-row">
       <aside
-        className={`relative flex w-full flex-col rounded-3xl border border-slate-800 bg-slate-900/60 transition-all duration-300 lg:w-auto ${
+        className={`relative flex w-full flex-col rounded-3xl border border-border bg-surface-muted/60 transition-all duration-300 lg:w-auto ${
           isCollapsed ? 'lg:max-w-[5.5rem] lg:p-4' : 'lg:max-w-xs lg:p-6'
         }`}
       >
         <button
           type="button"
           onClick={() => setCollapsed((prev) => !prev)}
-          className="absolute right-4 top-4 hidden h-9 w-9 items-center justify-center rounded-full border border-slate-700/70 text-slate-300 transition hover:border-emerald-500 hover:text-emerald-200 lg:flex"
+          className="absolute right-4 top-4 hidden h-9 w-9 items-center justify-center rounded-full border border-border/70 text-text-secondary transition hover:border-accent hover:text-accent/80 lg:flex"
           aria-label={isCollapsed ? 'Expand action menu' : 'Collapse action menu'}
         >
           <svg viewBox="0 0 24 24" className={`h-4 w-4 transition-transform ${isCollapsed ? 'rotate-180' : ''}`} aria-hidden="true">
@@ -138,25 +138,25 @@ function ProjectPage() {
                   }
                 }}
                 autoFocus
-                className="rounded-xl border border-emerald-500/70 bg-slate-950/80 px-4 py-2 text-lg font-semibold text-white outline-none focus:ring-2 focus:ring-emerald-500/40"
+                className="rounded-xl border border-accent/70 bg-surface/80 px-4 py-2 text-lg font-semibold text-text-primary outline-none focus:ring-2 focus:ring-accent/40"
               />
             ) : (
               <button
                 type="button"
                 onClick={() => setEditingTitle(true)}
-                className="text-left text-lg font-semibold text-white transition hover:text-emerald-200"
+                className="text-left text-lg font-semibold text-text-primary transition hover:text-accent/80"
               >
                 {project.name}
               </button>
             )}
-            <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Action Menu</p>
+            <p className="text-xs uppercase tracking-[0.3em] text-text-muted">Action Menu</p>
           </div>
 
           <div className="space-y-4">
-            <label className="block text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+            <label className="block text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
               Search project
-              <div className="mt-2 flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-950/70 px-3">
-                <svg viewBox="0 0 24 24" className="h-4 w-4 text-slate-500" aria-hidden="true">
+              <div className="mt-2 flex items-center gap-2 rounded-xl border border-border bg-surface/70 px-3">
+                <svg viewBox="0 0 24 24" className="h-4 w-4 text-text-muted" aria-hidden="true">
                   <path
                     fill="currentColor"
                     d="M10 4a6 6 0 014.62 9.8l4.29 4.29a.75.75 0 11-1.06 1.06l-4.29-4.29A6 6 0 1110 4zm0 1.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z"
@@ -166,7 +166,7 @@ function ProjectPage() {
                   value={searchQuery}
                   onChange={(event) => setSearchQuery(event.target.value)}
                   placeholder="Search items, assets, notes..."
-                  className="w-full bg-transparent py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none"
+                  className="w-full bg-transparent py-2 text-sm text-text-primary placeholder:text-text-muted focus:outline-none"
                   type="search"
                 />
               </div>
@@ -175,10 +175,10 @@ function ProjectPage() {
             <button
               type="button"
               onClick={() => setAssetBrowserOpen(true)}
-              className="flex w-full items-center justify-between rounded-2xl border border-slate-800/80 bg-slate-950/60 px-4 py-3 text-left text-sm font-semibold text-slate-200 transition hover:border-emerald-500/70 hover:text-emerald-100"
+              className="flex w-full items-center justify-between rounded-2xl border border-border/80 bg-surface/60 px-4 py-3 text-left text-sm font-semibold text-text-secondary transition hover:border-accent/70 hover:text-accent/80"
             >
               <span>Image Library</span>
-              <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-200">
+              <span className="rounded-full bg-accent/10 px-2 py-0.5 text-xs font-semibold text-accent/80">
                 {project.assets.length}
               </span>
             </button>
@@ -186,11 +186,11 @@ function ProjectPage() {
 
           <div className="space-y-3">
             <div className="flex items-center justify-between">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Items</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">Items</p>
               <button
                 type="button"
                 onClick={() => setItemDialogOpen(true)}
-                className="flex h-8 w-8 items-center justify-center rounded-md border border-slate-700/70 text-lg font-semibold text-slate-200 transition hover:border-emerald-500 hover:text-emerald-200"
+                className="flex h-8 w-8 items-center justify-center rounded-md border border-border/70 text-lg font-semibold text-text-secondary transition hover:border-accent hover:text-accent/80"
                 aria-label="Add item"
               >
                 +
@@ -199,20 +199,20 @@ function ProjectPage() {
 
             <div className="space-y-3">
               {filteredItems.length === 0 ? (
-                <p className="rounded-2xl border border-dashed border-slate-700/70 bg-slate-950/60 px-4 py-6 text-center text-xs text-slate-400">
+                <p className="rounded-2xl border border-dashed border-border/70 bg-surface/60 px-4 py-6 text-center text-xs text-text-muted">
                   No items match your search yet.
                 </p>
               ) : (
                 filteredItems.map((item) => (
                   <div
                     key={item.id}
-                    className="rounded-2xl border border-slate-800/80 bg-slate-950/70 px-4 py-4 text-sm text-slate-200 shadow-lg shadow-black/20"
+                    className="rounded-2xl border border-border/80 bg-surface/70 px-4 py-4 text-sm text-text-secondary shadow-lg shadow-black/20"
                   >
-                    <p className="font-semibold text-white">{item.name}</p>
-                    <p className="mt-1 text-xs uppercase tracking-[0.3em] text-slate-500">{item.type}</p>
-                    <p className="mt-2 text-xs text-slate-400">{item.variant}</p>
+                    <p className="font-semibold text-text-primary">{item.name}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.3em] text-text-muted">{item.type}</p>
+                    <p className="mt-2 text-xs text-text-muted">{item.variant}</p>
                     {item.customDetails && (
-                      <p className="mt-2 text-xs text-slate-500">{item.customDetails}</p>
+                      <p className="mt-2 text-xs text-text-muted">{item.customDetails}</p>
                     )}
                   </div>
                 ))
@@ -225,7 +225,7 @@ function ProjectPage() {
           <button
             type="button"
             onClick={() => setEditingTitle(true)}
-            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-700/70 text-white transition hover:border-emerald-500 hover:text-emerald-200"
+            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border/70 text-text-primary transition hover:border-accent hover:text-accent/80"
             title="Rename project"
           >
             ✎
@@ -233,7 +233,7 @@ function ProjectPage() {
           <button
             type="button"
             onClick={() => setAssetBrowserOpen(true)}
-            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-700/70 text-white transition hover:border-emerald-500 hover:text-emerald-200"
+            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border/70 text-text-primary transition hover:border-accent hover:text-accent/80"
             title="Image library"
           >
             🖼️
@@ -241,7 +241,7 @@ function ProjectPage() {
           <button
             type="button"
             onClick={() => setItemDialogOpen(true)}
-            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-700/70 text-white transition hover:border-emerald-500 hover:text-emerald-200"
+            className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border/70 text-text-primary transition hover:border-accent hover:text-accent/80"
             title="Add item"
           >
             +
@@ -251,36 +251,36 @@ function ProjectPage() {
 
       <section className="flex-1 space-y-6">
         {statusMessage && (
-          <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+          <div className="rounded-2xl border border-accent/40 bg-accent/10 px-4 py-3 text-sm text-accent/80">
             {statusMessage}
           </div>
         )}
 
-        <div className="rounded-3xl border border-slate-800 bg-slate-900/40 p-8">
-          <h2 className="text-2xl font-semibold text-white">Workspace</h2>
-          <p className="mt-3 max-w-2xl text-sm text-slate-300">
+        <div className="rounded-3xl border border-border bg-surface-muted/40 p-8">
+          <h2 className="text-2xl font-semibold text-text-primary">Workspace</h2>
+          <p className="mt-3 max-w-2xl text-sm text-text-secondary">
             Your items appear here as you build them out. Use the action menu to browse assets, add new components, and manage your
             project details. Drag-and-drop editing and placement tools will arrive in future updates.
           </p>
           <div className="mt-6 grid gap-4 sm:grid-cols-2">
             {project.items.map((item) => (
-              <div key={item.id} className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-4">
-                <p className="text-sm font-semibold text-white">{item.name}</p>
-                <p className="mt-1 text-xs uppercase tracking-[0.3em] text-slate-500">{item.type}</p>
-                <p className="mt-2 text-xs text-slate-400">{item.variant}</p>
-                {item.customDetails && <p className="mt-2 text-xs text-slate-500">Custom: {item.customDetails}</p>}
+              <div key={item.id} className="rounded-2xl border border-border/80 bg-surface/60 p-4">
+                <p className="text-sm font-semibold text-text-primary">{item.name}</p>
+                <p className="mt-1 text-xs uppercase tracking-[0.3em] text-text-muted">{item.type}</p>
+                <p className="mt-2 text-xs text-text-muted">{item.variant}</p>
+                {item.customDetails && <p className="mt-2 text-xs text-text-muted">Custom: {item.customDetails}</p>}
               </div>
             ))}
             {project.items.length === 0 && (
-              <div className="col-span-full flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-700/70 bg-slate-950/60 p-12 text-center">
-                <p className="text-lg font-semibold text-white">No items yet</p>
-                <p className="mt-2 max-w-sm text-sm text-slate-400">
+              <div className="col-span-full flex flex-col items-center justify-center rounded-2xl border border-dashed border-border/70 bg-surface/60 p-12 text-center">
+                <p className="text-lg font-semibold text-text-primary">No items yet</p>
+                <p className="mt-2 max-w-sm text-sm text-text-muted">
                   Add your first board, card deck, or poster using the action menu on the left.
                 </p>
                 <button
                   type="button"
                   onClick={() => setItemDialogOpen(true)}
-                  className="mt-4 rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400"
+                  className="mt-4 rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast transition hover:bg-accent-strong"
                 >
                   Add an item
                 </button>
@@ -289,24 +289,24 @@ function ProjectPage() {
           </div>
         </div>
 
-        <div className="rounded-3xl border border-slate-800 bg-slate-900/40 p-8">
-          <h3 className="text-xl font-semibold text-white">Project Activity</h3>
-          <p className="mt-2 text-sm text-slate-400">
+        <div className="rounded-3xl border border-border bg-surface-muted/40 p-8">
+          <h3 className="text-xl font-semibold text-text-primary">Project Activity</h3>
+          <p className="mt-2 text-sm text-text-muted">
             Keep track of asset uploads, layout tweaks, and collaborative notes. Future iterations will surface version history and
             assignable tasks.
           </p>
-          <ul className="mt-6 space-y-3 text-sm text-slate-300">
-            <li className="rounded-2xl border border-slate-800/70 bg-slate-950/60 px-4 py-3">
-              <span className="font-semibold text-white">{project.name}</span> is ready for exploration. Start adding details
-              to each component.
-            </li>
-            <li className="rounded-2xl border border-slate-800/70 bg-slate-950/60 px-4 py-3">
-              Upload reference art or icons to the image library to keep inspiration close at hand.
-            </li>
-          </ul>
-          <div className="mt-6 text-xs text-slate-500">
-            Looking for something else? <Link to="/" className="text-emerald-300 transition hover:text-emerald-200">Return to the dashboard</Link> to switch projects.
-          </div>
+            <ul className="mt-6 space-y-3 text-sm text-text-secondary">
+              <li className="rounded-2xl border border-border/70 bg-surface/60 px-4 py-3">
+                <span className="font-semibold text-text-primary">{project.name}</span> is ready for exploration. Start adding details
+                to each component.
+              </li>
+              <li className="rounded-2xl border border-border/70 bg-surface/60 px-4 py-3">
+                Upload reference art or icons to the image library to keep inspiration close at hand.
+              </li>
+            </ul>
+            <div className="mt-6 text-xs text-text-muted">
+              Looking for something else? <Link to="/" className="text-accent/80 transition hover:text-accent">Return to the dashboard</Link> to switch projects.
+            </div>
         </div>
       </section>
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -3,5 +3,21 @@
 @tailwind utilities;
 
 :root {
+  --color-background: 2 6 23;
+  --color-surface: 15 23 42;
+  --color-surface-muted: 17 28 48;
+  --color-surface-elevated: 30 41 59;
+  --color-border: 31 41 55;
+  --color-border-strong: 51 65 85;
+  --color-text-primary: 248 250 252;
+  --color-text-secondary: 226 232 240;
+  --color-text-muted: 148 163 184;
+  --color-text-inverse: 2 6 23;
+  --color-accent: 16 185 129;
+  --color-accent-strong: 52 211 153;
+  --color-accent-contrast: 2 44 34;
+  --color-overlay: 2 6 23;
+  --color-ring: 34 197 94;
+  --color-highlight: 52 211 153;
   color-scheme: dark;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,34 @@ export default {
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
       },
+      colors: {
+        background: 'rgb(var(--color-background) / <alpha-value>)',
+        surface: {
+          DEFAULT: 'rgb(var(--color-surface) / <alpha-value>)',
+          muted: 'rgb(var(--color-surface-muted) / <alpha-value>)',
+          elevated: 'rgb(var(--color-surface-elevated) / <alpha-value>)',
+        },
+        border: {
+          DEFAULT: 'rgb(var(--color-border) / <alpha-value>)',
+          strong: 'rgb(var(--color-border-strong) / <alpha-value>)',
+        },
+        text: {
+          primary: 'rgb(var(--color-text-primary) / <alpha-value>)',
+          secondary: 'rgb(var(--color-text-secondary) / <alpha-value>)',
+          muted: 'rgb(var(--color-text-muted) / <alpha-value>)',
+          inverse: 'rgb(var(--color-text-inverse) / <alpha-value>)',
+        },
+        accent: {
+          DEFAULT: 'rgb(var(--color-accent) / <alpha-value>)',
+          strong: 'rgb(var(--color-accent-strong) / <alpha-value>)',
+          contrast: 'rgb(var(--color-accent-contrast) / <alpha-value>)',
+        },
+        overlay: 'rgb(var(--color-overlay) / <alpha-value>)',
+        highlight: 'rgb(var(--color-highlight) / <alpha-value>)',
+      },
+      ringColor: {
+        DEFAULT: 'rgb(var(--color-ring) / <alpha-value>)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- introduce a theme context with preset palettes and a header theme switcher to make swapping looks trivial
- extend Tailwind to consume CSS variable tokens and seed default values for the existing palette
- refresh core surfaces, dialogs, and pages to reference the new theme tokens instead of hard coded slate/emerald colors

## Testing
- npm run build *(fails: TypeScript cannot resolve react-router-dom types in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d955803b7c832f87f361270722fdfb