### PR TITLE
Ensure active theme re-applies when presets change

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -52,21 +52,27 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_THEME_ID;
   });
 
-  useEffect(() => {
-    const activeTheme = THEME_PRESETS.find((candidate) => candidate.id === themeId) ?? THEME_PRESETS[0];
-    applyTheme(activeTheme);
-    localStorage.setItem(STORAGE_KEY, activeTheme.id);
+  const activeTheme = useMemo(() => {
+    return (
+      THEME_PRESETS.find((candidate) => candidate.id === themeId) ||
+      THEME_PRESETS.find((candidate) => candidate.id === DEFAULT_THEME_ID) ||
+      THEME_PRESETS[0]
+    );
   }, [themeId]);
 
+  useEffect(() => {
+    applyTheme(activeTheme);
+    localStorage.setItem(STORAGE_KEY, activeTheme.id);
+  }, [activeTheme]);
+
   const value = useMemo<ThemeContextValue>(() => {
-    const theme = THEME_PRESETS.find((candidate) => candidate.id === themeId) ?? THEME_PRESETS[0];
     return {
-      theme,
-      themeId: theme.id,
+      theme: activeTheme,
+      themeId: activeTheme.id,
       availableThemes: THEME_PRESETS,
       setThemeId,
     };
-  }, [themeId]);
+  }, [activeTheme]);
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- memoize the active theme with a fallback to the configured default preset
- reapply CSS variables and update context values whenever the active preset object changes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d978a08150832f97713fcafc8164b4