### PR TITLE
Improve interaction responsiveness in project views

### DIFF
--- a/src/components/ImageAssetBrowser.tsx
+++ b/src/components/ImageAssetBrowser.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useMemo, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { AssetInput, ProjectAsset } from '../context/ProjectContext';
 
@@ -33,17 +33,44 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
     event.target.value = '';
   };
 
-  const toggleSelected = (assetId: string) => {
-    setSelectedAssets((prev) =>
-      prev.includes(assetId) ? prev.filter((id) => id !== assetId) : [...prev, assetId],
-    );
-  };
+  const toggleSelected = useCallback((assetId: string) => {
+    setSelectedAssets((prev) => (prev.includes(assetId) ? prev.filter((id) => id !== assetId) : [...prev, assetId]));
+  }, []);
 
-  const clearStateAndClose = () => {
+  useEffect(() => {
+    if (selectedAssets.length === 0) {
+      return;
+    }
+
+    setSelectedAssets((prev) => {
+      const filtered = prev.filter((id) => assets.some((asset) => asset.id === id));
+      return filtered.length === prev.length ? prev : filtered;
+    });
+  }, [assets, selectedAssets.length]);
+
+  const clearStateAndClose = useCallback(() => {
     setSelectedAssets([]);
     setPreviewAssetId(null);
     onClose();
-  };
+  }, [onClose]);
+
+  const handleLocateSelected = useCallback(() => {
+    if (selectedAssets.length === 1) {
+      onLocateAsset(selectedAssets[0]);
+    }
+  }, [onLocateAsset, selectedAssets]);
+
+  const handleRemoveSelected = useCallback(() => {
+    if (selectedAssets.length > 0) {
+      onRemoveAssets(selectedAssets);
+    }
+  }, [onRemoveAssets, selectedAssets]);
+
+  const handlePreview = useCallback((assetId: string) => {
+    setPreviewAssetId(assetId);
+  }, []);
+
+  const selectedCount = selectedAssets.length;
 
   if (!open) {
     return null;
@@ -60,20 +87,16 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={() => {
-                if (selectedAssets.length === 1) {
-                  onLocateAsset(selectedAssets[0]);
-                }
-              }}
-              disabled={selectedAssets.length !== 1}
+              onClick={handleLocateSelected}
+              disabled={selectedCount !== 1}
               className="rounded-full border border-border/70 px-4 py-2 text-xs font-semibold text-text-secondary transition disabled:cursor-not-allowed disabled:opacity-50 hover:border-accent hover:text-accent/80"
             >
               Locate usage
             </button>
             <button
               type="button"
-              onClick={() => onRemoveAssets(selectedAssets)}
-              disabled={selectedAssets.length === 0}
+              onClick={handleRemoveSelected}
+              disabled={selectedCount === 0}
               className="rounded-full border border-rose-500/60 px-4 py-2 text-xs font-semibold text-rose-200 transition disabled:cursor-not-allowed disabled:opacity-50 hover:bg-rose-500/10"
             >
               Delete selected
@@ -120,13 +143,15 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
                     >
                       <button
                         type="button"
-                        onClick={() => setPreviewAssetId(asset.id)}
+                        onClick={() => handlePreview(asset.id)}
                         className="relative block h-40 w-full overflow-hidden bg-surface-muted/80"
                       >
                         <img
                           src={asset.url}
                           alt={asset.name}
-                          className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                          loading="lazy"
+                          decoding="async"
+                          className="h-full w-full object-cover transition duration-300 will-change-transform group-hover:scale-105"
                         />
                       </button>
                       <div className="flex items-center justify-between gap-2 border-t border-border/80 bg-surface-muted/80 px-3 py-3">

--- a/src/components/ProjectOverviewPanel.tsx
+++ b/src/components/ProjectOverviewPanel.tsx
@@ -1,3 +1,5 @@
+import { memo, useCallback, useMemo } from 'react';
+
 import { Project } from '../context/ProjectContext';
 
 interface ProjectOverviewPanelProps {
@@ -5,6 +7,63 @@ interface ProjectOverviewPanelProps {
   onOpenProject: (projectId: string) => void;
   onCreateProject: () => void;
 }
+
+interface ProjectCardProps {
+  project: Project;
+  onOpenProject: (projectId: string) => void;
+}
+
+const ProjectCard = memo(({ project, onOpenProject }: ProjectCardProps) => {
+  const { previewItems, remainingItemCount } = useMemo(() => {
+    const previewItems = project.items.slice(0, 3);
+    const remainingItemCount = Math.max(project.items.length - previewItems.length, 0);
+
+    return { previewItems, remainingItemCount };
+  }, [project.items]);
+
+  const handleOpen = useCallback(() => onOpenProject(project.id), [onOpenProject, project.id]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleOpen}
+      className="group flex flex-col rounded-2xl border border-border/80 bg-surface/60 p-6 text-left shadow-lg shadow-black/30 transition will-change-transform hover:-translate-y-1 hover:border-accent/70 hover:bg-surface-muted/80 hover:shadow-accent/30"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.25em] text-text-muted">Project</p>
+          <h3 className="mt-2 text-xl font-semibold text-text-primary transition group-hover:text-accent/80">{project.name}</h3>
+        </div>
+        <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-accent/10 text-accent/80 transition group-hover:bg-accent-strong/20">
+          <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 transform transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5">
+            <path
+              fill="currentColor"
+              d="M8.75 7.25a.75.75 0 011.5 0v6.69l6.22-6.22a.75.75 0 011.06 1.06l-6.22 6.22h6.69a.75.75 0 010 1.5h-8.5a.75.75 0 01-.75-.75z"
+            />
+          </svg>
+        </span>
+      </div>
+      <p className="mt-4 text-sm text-text-muted">
+        {project.items.length > 0
+          ? `${project.items.length} item${project.items.length === 1 ? '' : 's'} ready to refine`
+          : 'No items added yet — jump in to get started.'}
+      </p>
+      {previewItems.length > 0 && (
+        <ul className="mt-4 space-y-2 text-sm text-text-secondary">
+          {previewItems.map((item) => (
+            <li key={item.id} className="flex items-center gap-2">
+              <span className="h-1.5 w-1.5 rounded-full bg-highlight" aria-hidden />
+              <span>{item.name}</span>
+            </li>
+          ))}
+          {remainingItemCount > 0 && <li className="text-xs uppercase tracking-widest text-text-muted">+{remainingItemCount} more</li>}
+        </ul>
+      )}
+    </button>
+  );
+});
+
+ProjectCard.displayName = 'ProjectCard';
 
 function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject }: ProjectOverviewPanelProps) {
   return (
@@ -45,59 +104,13 @@ function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject }: Proj
             </button>
           </div>
         ) : (
-          projects.map((project) => (
-            <button
-              key={project.id}
-              type="button"
-              onClick={() => onOpenProject(project.id)}
-              className="group flex flex-col rounded-2xl border border-border/80 bg-surface/60 p-6 text-left shadow-lg shadow-black/30 transition hover:-translate-y-1 hover:border-accent/70 hover:bg-surface-muted/80 hover:shadow-accent/30"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="text-xs uppercase tracking-[0.25em] text-text-muted">Project</p>
-                  <h3 className="mt-2 text-xl font-semibold text-text-primary transition group-hover:text-accent/80">
-                    {project.name}
-                  </h3>
-                </div>
-                <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-accent/10 text-accent/80 transition group-hover:bg-accent-strong/20">
-                  <svg
-                    aria-hidden="true"
-                    viewBox="0 0 24 24"
-                    className="h-5 w-5 transform transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M8.75 7.25a.75.75 0 011.5 0v6.69l6.22-6.22a.75.75 0 011.06 1.06l-6.22 6.22h6.69a.75.75 0 010 1.5h-8.5a.75.75 0 01-.75-.75z"
-                    />
-                  </svg>
-                </span>
-              </div>
-              <p className="mt-4 text-sm text-text-muted">
-                {project.items.length > 0
-                  ? `${project.items.length} item${project.items.length === 1 ? '' : 's'} ready to refine`
-                  : 'No items added yet — jump in to get started.'}
-              </p>
-              {project.items.length > 0 && (
-                <ul className="mt-4 space-y-2 text-sm text-text-secondary">
-                  {project.items.slice(0, 3).map((item) => (
-                    <li key={item.id} className="flex items-center gap-2">
-                      <span className="h-1.5 w-1.5 rounded-full bg-highlight" aria-hidden />
-                      <span>{item.name}</span>
-                    </li>
-                  ))}
-                  {project.items.length > 3 && (
-                    <li className="text-xs uppercase tracking-widest text-text-muted">
-                      +{project.items.length - 3} more
-                    </li>
-                  )}
-                </ul>
-              )}
-            </button>
-          ))
+          projects.map((project) => <ProjectCard key={project.id} project={project} onOpenProject={onOpenProject} />)
         )}
       </div>
     </section>
   );
 }
 
-export default ProjectOverviewPanel;
+ProjectOverviewPanel.displayName = 'ProjectOverviewPanel';
+
+export default memo(ProjectOverviewPanel);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import ProjectOverviewPanel from '../components/ProjectOverviewPanel';
@@ -11,15 +11,33 @@ function Home() {
   const { projects, createProject } = useProjects();
   const [isDialogOpen, setDialogOpen] = useState(false);
 
-  const handleCreateProject = ({ name, initialItem }: { name: string; initialItem?: ItemInput }) => {
-    const project = createProject({ name, initialItem });
-    setDialogOpen(false);
-    navigate(`/projects/${project.id}`);
-  };
+  const handleCreateProject = useCallback(
+    ({ name, initialItem }: { name: string; initialItem?: ItemInput }) => {
+      const project = createProject({ name, initialItem });
+      setDialogOpen(false);
+      navigate(`/projects/${project.id}`);
+    },
+    [createProject, navigate],
+  );
 
-  const handleOpenProject = (projectId: string) => {
-    navigate(`/projects/${projectId}`);
-  };
+  const handleOpenProject = useCallback(
+    (projectId: string) => {
+      navigate(`/projects/${projectId}`);
+    },
+    [navigate],
+  );
+
+  const handleOpenDialog = useCallback(() => setDialogOpen(true), []);
+  const handleCloseDialog = useCallback(() => setDialogOpen(false), []);
+
+  const dialogProps = useMemo(
+    () => ({
+      open: isDialogOpen,
+      onClose: handleCloseDialog,
+      onCreate: handleCreateProject,
+    }),
+    [handleCloseDialog, handleCreateProject, isDialogOpen],
+  );
 
   return (
     <>
@@ -36,14 +54,10 @@ function Home() {
           </p>
         </div>
 
-        <ProjectOverviewPanel
-          projects={projects}
-          onOpenProject={handleOpenProject}
-          onCreateProject={() => setDialogOpen(true)}
-        />
+        <ProjectOverviewPanel projects={projects} onOpenProject={handleOpenProject} onCreateProject={handleOpenDialog} />
       </section>
 
-      <NewProjectDialog open={isDialogOpen} onClose={() => setDialogOpen(false)} onCreate={handleCreateProject} />
+      <NewProjectDialog {...dialogProps} />
     </>
   );
 }

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -1,10 +1,17 @@
-import { useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import ImageAssetBrowser from '../components/ImageAssetBrowser';
 import NewItemDialog from '../components/NewItemDialog';
 import { AssetInput, ItemInput, Project } from '../context/ProjectContext';
 import { findProject, useProjects } from '../context/ProjectContext';
+
+const emptyAssetBrowserHandlers = Object.freeze({
+  onClose: () => undefined,
+  onAddAssets: (_assets: AssetInput[]) => undefined,
+  onRemoveAssets: (_assetIds: string[]) => undefined,
+  onLocateAsset: (_assetId: string) => undefined,
+});
 
 function ProjectPage() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -31,6 +38,8 @@ function ProjectPage() {
     }
   }, [project]);
 
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+
   useEffect(() => {
     if (statusMessage) {
       const timeout = setTimeout(() => setStatusMessage(null), 4000);
@@ -38,6 +47,133 @@ function ProjectPage() {
     }
     return undefined;
   }, [statusMessage]);
+
+  const handleToggleCollapsed = useCallback(() => {
+    setCollapsed((prev) => !prev);
+  }, []);
+
+  const handleStartEditingTitle = useCallback(() => {
+    setEditingTitle(true);
+  }, []);
+
+  const handleSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  }, []);
+
+  const handleOpenItemDialog = useCallback(() => setItemDialogOpen(true), []);
+  const handleCloseItemDialog = useCallback(() => setItemDialogOpen(false), []);
+
+  const handleOpenAssetBrowser = useCallback(() => setAssetBrowserOpen(true), []);
+  const handleCloseAssetBrowser = useCallback(() => setAssetBrowserOpen(false), []);
+
+  const handleRename = useCallback(() => {
+    if (!project) {
+      return;
+    }
+
+    const trimmed = titleValue.trim();
+    if (!trimmed || trimmed === project.name) {
+      setTitleValue(project.name);
+      setEditingTitle(false);
+      return;
+    }
+
+    updateProjectName(project.id, trimmed);
+    setEditingTitle(false);
+    setStatusMessage('Project name updated');
+  }, [project, titleValue, updateProjectName]);
+
+  const handleAddItem = useCallback(
+    (item: ItemInput) => {
+      if (!project) {
+        return;
+      }
+
+      addItemToProject(project.id, item);
+      setStatusMessage(`${item.name} added to ${project.name}`);
+    },
+    [addItemToProject, project],
+  );
+
+  const handleAddAssets = useCallback(
+    (assets: AssetInput[]) => {
+      if (!project || assets.length === 0) {
+        return;
+      }
+
+      addAssetsToProject(project.id, assets);
+      setStatusMessage(`${assets.length} asset${assets.length === 1 ? '' : 's'} added to the library`);
+    },
+    [addAssetsToProject, project],
+  );
+
+  const handleRemoveAssets = useCallback(
+    (assetIds: string[]) => {
+      if (!project || assetIds.length === 0) {
+        return;
+      }
+
+      removeAssetsFromProject(project.id, assetIds);
+      setStatusMessage(`${assetIds.length} asset${assetIds.length === 1 ? '' : 's'} deleted`);
+    },
+    [project, removeAssetsFromProject],
+  );
+
+  const handleLocateAsset = useCallback(
+    (assetId: string) => {
+      if (!project) {
+        return;
+      }
+
+      const asset = project.assets.find((candidate) => candidate.id === assetId);
+      if (asset) {
+        setStatusMessage(`Coming soon: locate "${asset.name}" within your layouts.`);
+      }
+    },
+    [project],
+  );
+
+  const filteredItems = useMemo(() => {
+    if (!project) {
+      return [];
+    }
+
+    const normalizedQuery = deferredSearchQuery.trim().toLowerCase();
+    if (normalizedQuery.length === 0) {
+      return project.items;
+    }
+
+    return project.items.filter((item) => item.name.toLowerCase().includes(normalizedQuery));
+  }, [deferredSearchQuery, project]);
+
+  const asideDynamicClasses = useMemo(
+    () =>
+      `relative flex w-full flex-col rounded-3xl border border-border bg-surface-muted/60 transition-all duration-300 lg:w-auto ${
+        isCollapsed ? 'lg:max-w-[5.5rem] lg:p-4' : 'lg:max-w-xs lg:p-6'
+      }`,
+    [isCollapsed],
+  );
+
+  const asideContentOpacityClass = isCollapsed ? 'opacity-0 pointer-events-none lg:hidden' : 'opacity-100';
+
+  const assetBrowserProps = useMemo(() => {
+    if (!project) {
+      return {
+        open: false,
+        assets: [],
+        ...emptyAssetBrowserHandlers,
+      };
+    }
+
+    return {
+      open: isAssetBrowserOpen,
+      assets: project.assets,
+      onClose: handleCloseAssetBrowser,
+      onAddAssets: handleAddAssets,
+      onRemoveAssets: handleRemoveAssets,
+      onLocateAsset: handleLocateAsset,
+    };
+  }, [handleAddAssets, handleCloseAssetBrowser, handleLocateAsset, handleRemoveAssets, isAssetBrowserOpen, project]);
 
   if (!project) {
     return (
@@ -58,58 +194,14 @@ function ProjectPage() {
     );
   }
 
-  const filteredItems = project.items.filter((item) =>
-    item.name.toLowerCase().includes(searchQuery.toLowerCase()),
-  );
-
-  const handleRename = () => {
-    const trimmed = titleValue.trim();
-    if (!trimmed || trimmed === project.name) {
-      setTitleValue(project.name);
-      setEditingTitle(false);
-      return;
-    }
-
-    updateProjectName(project.id, trimmed);
-    setEditingTitle(false);
-    setStatusMessage('Project name updated');
-  };
-
-  const handleAddItem = (item: ItemInput) => {
-    addItemToProject(project.id, item);
-    setStatusMessage(`${item.name} added to ${project.name}`);
-  };
-
-  const handleAddAssets = (assets: AssetInput[]) => {
-    addAssetsToProject(project.id, assets);
-    setStatusMessage(`${assets.length} asset${assets.length === 1 ? '' : 's'} added to the library`);
-  };
-
-  const handleRemoveAssets = (assetIds: string[]) => {
-    if (assetIds.length === 0) {
-      return;
-    }
-    removeAssetsFromProject(project.id, assetIds);
-    setStatusMessage(`${assetIds.length} asset${assetIds.length === 1 ? '' : 's'} deleted`);
-  };
-
-  const handleLocateAsset = (assetId: string) => {
-    const asset = project.assets.find((candidate) => candidate.id === assetId);
-    if (asset) {
-      setStatusMessage(`Coming soon: locate "${asset.name}" within your layouts.`);
-    }
-  };
+  const assetCount = project.assets.length;
 
   return (
     <div className="flex flex-col gap-6 lg:flex-row">
-      <aside
-        className={`relative flex w-full flex-col rounded-3xl border border-border bg-surface-muted/60 transition-all duration-300 lg:w-auto ${
-          isCollapsed ? 'lg:max-w-[5.5rem] lg:p-4' : 'lg:max-w-xs lg:p-6'
-        }`}
-      >
+      <aside className={asideDynamicClasses}>
         <button
           type="button"
-          onClick={() => setCollapsed((prev) => !prev)}
+          onClick={handleToggleCollapsed}
           className="absolute right-4 top-4 hidden h-9 w-9 items-center justify-center rounded-full border border-border/70 text-text-secondary transition hover:border-accent hover:text-accent/80 lg:flex"
           aria-label={isCollapsed ? 'Expand action menu' : 'Collapse action menu'}
         >
@@ -121,7 +213,7 @@ function ProjectPage() {
           </svg>
         </button>
 
-        <div className={`flex-1 space-y-6 transition-opacity duration-200 ${isCollapsed ? 'opacity-0 pointer-events-none lg:hidden' : 'opacity-100'}`}>
+        <div className={`flex-1 space-y-6 transition-opacity duration-200 ${asideContentOpacityClass}`}>
           <div className="flex flex-col gap-2 pr-10">
             {isEditingTitle ? (
               <input
@@ -143,7 +235,7 @@ function ProjectPage() {
             ) : (
               <button
                 type="button"
-                onClick={() => setEditingTitle(true)}
+                onClick={handleStartEditingTitle}
                 className="text-left text-lg font-semibold text-text-primary transition hover:text-accent/80"
               >
                 {project.name}
@@ -164,7 +256,7 @@ function ProjectPage() {
                 </svg>
                 <input
                   value={searchQuery}
-                  onChange={(event) => setSearchQuery(event.target.value)}
+                  onChange={handleSearchChange}
                   placeholder="Search items, assets, notes..."
                   className="w-full bg-transparent py-2 text-sm text-text-primary placeholder:text-text-muted focus:outline-none"
                   type="search"
@@ -174,13 +266,11 @@ function ProjectPage() {
 
             <button
               type="button"
-              onClick={() => setAssetBrowserOpen(true)}
+              onClick={handleOpenAssetBrowser}
               className="flex w-full items-center justify-between rounded-2xl border border-border/80 bg-surface/60 px-4 py-3 text-left text-sm font-semibold text-text-secondary transition hover:border-accent/70 hover:text-accent/80"
             >
               <span>Image Library</span>
-              <span className="rounded-full bg-accent/10 px-2 py-0.5 text-xs font-semibold text-accent/80">
-                {project.assets.length}
-              </span>
+              <span className="rounded-full bg-accent/10 px-2 py-0.5 text-xs font-semibold text-accent/80">{assetCount}</span>
             </button>
           </div>
 
@@ -189,7 +279,7 @@ function ProjectPage() {
               <p className="text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">Items</p>
               <button
                 type="button"
-                onClick={() => setItemDialogOpen(true)}
+                onClick={handleOpenItemDialog}
                 className="flex h-8 w-8 items-center justify-center rounded-md border border-border/70 text-lg font-semibold text-text-secondary transition hover:border-accent hover:text-accent/80"
                 aria-label="Add item"
               >
@@ -211,9 +301,7 @@ function ProjectPage() {
                     <p className="font-semibold text-text-primary">{item.name}</p>
                     <p className="mt-1 text-xs uppercase tracking-[0.3em] text-text-muted">{item.type}</p>
                     <p className="mt-2 text-xs text-text-muted">{item.variant}</p>
-                    {item.customDetails && (
-                      <p className="mt-2 text-xs text-text-muted">{item.customDetails}</p>
-                    )}
+                    {item.customDetails && <p className="mt-2 text-xs text-text-muted">{item.customDetails}</p>}
                   </div>
                 ))
               )}
@@ -224,7 +312,7 @@ function ProjectPage() {
         <div className={`hidden flex-1 flex-col items-center gap-8 py-12 ${isCollapsed ? 'lg:flex' : 'lg:hidden'}`}>
           <button
             type="button"
-            onClick={() => setEditingTitle(true)}
+            onClick={handleStartEditingTitle}
             className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border/70 text-text-primary transition hover:border-accent hover:text-accent/80"
             title="Rename project"
           >
@@ -232,7 +320,7 @@ function ProjectPage() {
           </button>
           <button
             type="button"
-            onClick={() => setAssetBrowserOpen(true)}
+            onClick={handleOpenAssetBrowser}
             className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border/70 text-text-primary transition hover:border-accent hover:text-accent/80"
             title="Image library"
           >
@@ -240,7 +328,7 @@ function ProjectPage() {
           </button>
           <button
             type="button"
-            onClick={() => setItemDialogOpen(true)}
+            onClick={handleOpenItemDialog}
             className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border/70 text-text-primary transition hover:border-accent hover:text-accent/80"
             title="Add item"
           >
@@ -251,9 +339,7 @@ function ProjectPage() {
 
       <section className="flex-1 space-y-6">
         {statusMessage && (
-          <div className="rounded-2xl border border-accent/40 bg-accent/10 px-4 py-3 text-sm text-accent/80">
-            {statusMessage}
-          </div>
+          <div className="rounded-2xl border border-accent/40 bg-accent/10 px-4 py-3 text-sm text-accent/80">{statusMessage}</div>
         )}
 
         <div className="rounded-3xl border border-border bg-surface-muted/40 p-8">
@@ -279,7 +365,7 @@ function ProjectPage() {
                 </p>
                 <button
                   type="button"
-                  onClick={() => setItemDialogOpen(true)}
+                  onClick={handleOpenItemDialog}
                   className="mt-4 rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast transition hover:bg-accent-strong"
                 >
                   Add an item
@@ -310,16 +396,9 @@ function ProjectPage() {
         </div>
       </section>
 
-      <NewItemDialog open={isItemDialogOpen} onClose={() => setItemDialogOpen(false)} onSubmit={handleAddItem} />
+      <NewItemDialog open={isItemDialogOpen} onClose={handleCloseItemDialog} onSubmit={handleAddItem} />
 
-      <ImageAssetBrowser
-        open={isAssetBrowserOpen}
-        assets={project.assets}
-        onClose={() => setAssetBrowserOpen(false)}
-        onAddAssets={handleAddAssets}
-        onRemoveAssets={handleRemoveAssets}
-        onLocateAsset={handleLocateAsset}
-      />
+      <ImageAssetBrowser {...assetBrowserProps} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- memoize the home dashboard project cards and dialog props to avoid unnecessary re-renders
- streamline ProjectPage event handlers and filtering with memoized callbacks and deferred search updates
- optimize the image asset browser selection state and enable lazy-loaded previews for smoother interactions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d986d709f0832fb02ede9b5f79bd84