### PR TITLE
Reduce modal overlay blur to improve responsiveness

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import ProjectPage from './pages/ProjectPage';
 function App() {
   return (
     <div className="min-h-screen bg-background font-sans text-text-primary">
-      <header className="border-b border-border bg-surface/80 backdrop-blur">
+      <header className="border-b border-border bg-surface/90">
         <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 py-6 text-center sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-2xl font-semibold tracking-tight text-text-primary sm:text-3xl">
             Tabletop Creator – Your Friendly Game Design Companion

--- a/src/components/ImageAssetBrowser.tsx
+++ b/src/components/ImageAssetBrowser.tsx
@@ -77,7 +77,7 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/70 p-6 backdrop-blur">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/80 p-6">
       <div className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60">
         <div className="flex items-center justify-between border-b border-border/70 px-8 py-6">
           <div>

--- a/src/components/NewItemDialog.tsx
+++ b/src/components/NewItemDialog.tsx
@@ -63,7 +63,7 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/70 p-4 backdrop-blur">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/80 p-4">
       <div className="w-full max-w-2xl rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60">
         <div className="flex items-center justify-between border-b border-border/70 px-6 py-5">
           <div>

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -77,7 +77,7 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/70 p-4 backdrop-blur">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/80 p-4">
       <div className="w-full max-w-3xl rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60">
         <div className="flex items-center justify-between border-b border-border/70 px-8 py-6">
           <div>


### PR DESCRIPTION
## Summary
- remove the backdrop blur filter from the global header and modal overlays
- keep opaque overlays so dialogs remain readable without triggering heavy GPU work

## Testing
- npm run lint *(fails: existing lint errors around unused variables in ProjectPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d98a8d9888832fa03ba606e0de7001