### PR TITLE
Persist projects per user and sync client context

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,34 @@ type DbUser = {
   verification_token: string | null;
 };
 
+type DbProject = {
+  id: string;
+  user_id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  favorite: number;
+};
+
+type DbProjectItem = {
+  id: string;
+  project_id: string;
+  name: string;
+  type: string;
+  variant: string;
+  custom_details: string | null;
+  created_at: string;
+};
+
+type DbProjectAsset = {
+  id: string;
+  project_id: string;
+  name: string;
+  url: string;
+  created_at: string;
+};
+
+/* eslint-disable @typescript-eslint/no-namespace */
 declare global {
   namespace Express {
     interface Request {
@@ -27,6 +55,7 @@ declare global {
     }
   }
 }
+/* eslint-enable @typescript-eslint/no-namespace */
 
 const app = express();
 const PORT = Number(process.env.PORT ?? 4000);
@@ -39,6 +68,7 @@ const DATABASE_FILE = process.env.DATABASE_FILE ?? path.join(process.cwd(), 'aut
 // Initialise a simple SQLite database to persist users locally.
 const db = new Database(DATABASE_FILE);
 db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
 db.prepare(
   `CREATE TABLE IF NOT EXISTS users (
     id TEXT PRIMARY KEY,
@@ -49,6 +79,148 @@ db.prepare(
     verification_token TEXT
   )`
 ).run();
+db.prepare(
+  `CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    favorite INTEGER NOT NULL DEFAULT 0 CHECK(favorite IN (0, 1))
+  )`
+).run();
+db.prepare(
+  `CREATE TABLE IF NOT EXISTS project_items (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    variant TEXT NOT NULL,
+    custom_details TEXT,
+    created_at TEXT NOT NULL
+  )`
+).run();
+db.prepare(
+  `CREATE TABLE IF NOT EXISTS project_assets (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    url TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  )`
+).run();
+
+const selectProjectsByUserStatement = db.prepare(
+  `SELECT * FROM projects WHERE user_id = ? ORDER BY datetime(updated_at) DESC`,
+);
+
+const selectProjectByIdStatement = db.prepare(
+  `SELECT * FROM projects WHERE id = ? AND user_id = ?`,
+);
+
+const selectItemsForProjectStatement = db.prepare(
+  `SELECT * FROM project_items WHERE project_id = ? ORDER BY datetime(created_at) ASC`,
+);
+
+const selectAssetsForProjectStatement = db.prepare(
+  `SELECT * FROM project_assets WHERE project_id = ? ORDER BY datetime(created_at) ASC`,
+);
+
+const insertProjectStatement = db.prepare(
+  `INSERT INTO projects (id, user_id, name, created_at, updated_at, favorite)
+   VALUES (?, ?, ?, ?, ?, 0)`,
+);
+
+const updateProjectStatement = db.prepare(
+  `UPDATE projects
+     SET name = COALESCE(?, name),
+         favorite = COALESCE(?, favorite),
+         updated_at = ?
+   WHERE id = ? AND user_id = ?`,
+);
+
+const insertProjectItemStatement = db.prepare(
+  `INSERT INTO project_items (id, project_id, name, type, variant, custom_details, created_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?)`,
+);
+
+const insertProjectAssetStatement = db.prepare(
+  `INSERT INTO project_assets (id, project_id, name, url, created_at)
+   VALUES (?, ?, ?, ?, ?)`,
+);
+
+const touchProjectStatement = db.prepare(
+  `UPDATE projects SET updated_at = ? WHERE id = ? AND user_id = ?`,
+);
+
+type ApiProjectItem = {
+  id: string;
+  name: string;
+  type: string;
+  variant: string;
+  customDetails?: string;
+};
+
+type ApiProjectAsset = {
+  id: string;
+  name: string;
+  url: string;
+};
+
+type ApiProject = {
+  id: string;
+  name: string;
+  items: ApiProjectItem[];
+  assets: ApiProjectAsset[];
+  updatedAt: string;
+  favorite: boolean;
+};
+
+function mapItem(row: DbProjectItem): ApiProjectItem {
+  return {
+    id: row.id,
+    name: row.name,
+    type: row.type,
+    variant: row.variant,
+    customDetails: row.custom_details ?? undefined,
+  } satisfies ApiProjectItem;
+}
+
+function mapAsset(row: DbProjectAsset): ApiProjectAsset {
+  return {
+    id: row.id,
+    name: row.name,
+    url: row.url,
+  } satisfies ApiProjectAsset;
+}
+
+function serializeProject(project: DbProject): ApiProject {
+  const items = selectItemsForProjectStatement.all(project.id) as DbProjectItem[];
+  const assets = selectAssetsForProjectStatement.all(project.id) as DbProjectAsset[];
+
+  return {
+    id: project.id,
+    name: project.name,
+    items: items.map(mapItem),
+    assets: assets.map(mapAsset),
+    updatedAt: project.updated_at,
+    favorite: Boolean(project.favorite),
+  } satisfies ApiProject;
+}
+
+function listProjects(userId: string): ApiProject[] {
+  const projects = selectProjectsByUserStatement.all(userId) as DbProject[];
+  return projects.map(serializeProject);
+}
+
+function loadProject(projectId: string, userId: string): ApiProject | undefined {
+  const project = selectProjectByIdStatement.get(projectId, userId) as DbProject | undefined;
+  if (!project) {
+    return undefined;
+  }
+
+  return serializeProject(project);
+}
 
 type Mailer = {
   transporter: nodemailer.Transporter;
@@ -111,6 +283,44 @@ const verifySchema = z.object({
 const loginSchema = z.object({
   email: z.string().email('Please provide a valid email.'),
   password: z.string().min(1, 'Password is required.'),
+});
+
+const projectItemTypeSchema = z.enum(['board', 'cardDeck', 'questPoster', 'custom']);
+
+const projectItemInputSchema = z.object({
+  name: z.string().trim().min(1, 'Item name is required.'),
+  type: projectItemTypeSchema,
+  variant: z.string().trim().min(1, 'Variant is required.'),
+  customDetails: z.string().optional(),
+});
+
+const createProjectSchema = z.object({
+  name: z.string().trim().min(1, 'Project name is required.'),
+  initialItem: projectItemInputSchema.optional(),
+});
+
+const updateProjectSchema = z
+  .object({
+    name: z.string().trim().min(1, 'Project name is required.').optional(),
+    favorite: z.boolean().optional(),
+  })
+  .refine((data) => data.name !== undefined || data.favorite !== undefined, {
+    message: 'Provide at least one field to update.',
+  });
+
+const addAssetsSchema = z.object({
+  assets: z
+    .array(
+      z.object({
+        name: z.string().trim().min(1, 'Asset name is required.'),
+        url: z.string().trim().min(1, 'Asset URL is required.'),
+      }),
+    )
+    .min(1, 'Provide at least one asset to add.'),
+});
+
+const removeAssetsSchema = z.object({
+  assetIds: z.array(z.string().min(1)).min(1, 'Provide at least one asset to remove.'),
 });
 
 function createJwt(user: { id: string; email: string }) {
@@ -311,11 +521,230 @@ app.get('/api/auth/me', requireAuth, (req, res) => {
   return res.json({ user: req.user });
 });
 
+app.get('/api/projects', requireAuth, (req, res) => {
+  const userId = req.user!.id;
+  try {
+    const projects = listProjects(userId);
+    return res.json({ projects });
+  } catch (error: unknown) {
+    console.error('Failed to list projects', error);
+    return res.status(500).json({ message: 'Unable to fetch projects. Please try again.' });
+  }
+});
+
+app.post('/api/projects', requireAuth, (req, res) => {
+  const parsed = createProjectSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid input.' });
+  }
+
+  const { name, initialItem } = parsed.data;
+  const userId = req.user!.id;
+  const projectId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const transaction = db.transaction(() => {
+    insertProjectStatement.run(projectId, userId, name.trim(), now, now);
+
+    if (initialItem) {
+      const itemId = crypto.randomUUID();
+      insertProjectItemStatement.run(
+        itemId,
+        projectId,
+        initialItem.name.trim(),
+        initialItem.type,
+        initialItem.variant.trim(),
+        initialItem.customDetails?.trim() || null,
+        now,
+      );
+    }
+  });
+
+  try {
+    transaction();
+  } catch (error: unknown) {
+    console.error('Failed to create project', error);
+    return res.status(500).json({ message: 'Could not create project. Please try again.' });
+  }
+
+  const project = loadProject(projectId, userId);
+  if (!project) {
+    return res.status(500).json({ message: 'Project could not be loaded after creation.' });
+  }
+
+  return res.status(201).json({ project });
+});
+
+app.patch('/api/projects/:projectId', requireAuth, (req, res) => {
+  const parsed = updateProjectSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid input.' });
+  }
+
+  const { projectId } = req.params;
+  const userId = req.user!.id;
+  const existing = selectProjectByIdStatement.get(projectId, userId) as DbProject | undefined;
+
+  if (!existing) {
+    return res.status(404).json({ message: 'Project not found.' });
+  }
+
+  const now = new Date().toISOString();
+  const favoriteValue = parsed.data.favorite === undefined ? null : parsed.data.favorite ? 1 : 0;
+
+  try {
+    updateProjectStatement.run(parsed.data.name?.trim() ?? null, favoriteValue, now, projectId, userId);
+  } catch (error: unknown) {
+    console.error('Failed to update project', error);
+    return res.status(500).json({ message: 'Could not update project. Please try again.' });
+  }
+
+  const project = loadProject(projectId, userId);
+  if (!project) {
+    return res.status(500).json({ message: 'Project could not be loaded after update.' });
+  }
+
+  return res.json({ project });
+});
+
+app.post('/api/projects/:projectId/items', requireAuth, (req, res) => {
+  const parsed = projectItemInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid input.' });
+  }
+
+  const { projectId } = req.params;
+  const userId = req.user!.id;
+  const existing = selectProjectByIdStatement.get(projectId, userId) as DbProject | undefined;
+
+  if (!existing) {
+    return res.status(404).json({ message: 'Project not found.' });
+  }
+
+  const itemId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const transaction = db.transaction(() => {
+    insertProjectItemStatement.run(
+      itemId,
+      projectId,
+      parsed.data.name.trim(),
+      parsed.data.type,
+      parsed.data.variant.trim(),
+      parsed.data.customDetails?.trim() || null,
+      now,
+    );
+    touchProjectStatement.run(now, projectId, userId);
+  });
+
+  try {
+    transaction();
+  } catch (error: unknown) {
+    console.error('Failed to add project item', error);
+    return res.status(500).json({ message: 'Could not add item to project. Please try again.' });
+  }
+
+  const project = loadProject(projectId, userId);
+  if (!project) {
+    return res.status(500).json({ message: 'Project could not be loaded after adding the item.' });
+  }
+
+  const item = project.items.find((candidate) => candidate.id === itemId);
+
+  return res.status(201).json({ item, project });
+});
+
+app.post('/api/projects/:projectId/assets', requireAuth, (req, res) => {
+  const parsed = addAssetsSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid input.' });
+  }
+
+  const { projectId } = req.params;
+  const userId = req.user!.id;
+  const existing = selectProjectByIdStatement.get(projectId, userId) as DbProject | undefined;
+
+  if (!existing) {
+    return res.status(404).json({ message: 'Project not found.' });
+  }
+
+  const createdAssets: ApiProjectAsset[] = [];
+  const now = new Date().toISOString();
+
+  const transaction = db.transaction(() => {
+    for (const asset of parsed.data.assets) {
+      const assetId = crypto.randomUUID();
+      const trimmedName = asset.name.trim();
+      const trimmedUrl = asset.url.trim();
+      insertProjectAssetStatement.run(assetId, projectId, trimmedName, trimmedUrl, now);
+      createdAssets.push({ id: assetId, name: trimmedName, url: trimmedUrl });
+    }
+
+    touchProjectStatement.run(now, projectId, userId);
+  });
+
+  try {
+    transaction();
+  } catch (error: unknown) {
+    console.error('Failed to add project assets', error);
+    return res.status(500).json({ message: 'Could not add assets. Please try again.' });
+  }
+
+  const project = loadProject(projectId, userId);
+  if (!project) {
+    return res.status(500).json({ message: 'Project could not be loaded after adding assets.' });
+  }
+
+  return res.status(201).json({ assets: createdAssets, project });
+});
+
+app.delete('/api/projects/:projectId/assets', requireAuth, (req, res) => {
+  const parsed = removeAssetsSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid input.' });
+  }
+
+  const { projectId } = req.params;
+  const userId = req.user!.id;
+  const existing = selectProjectByIdStatement.get(projectId, userId) as DbProject | undefined;
+
+  if (!existing) {
+    return res.status(404).json({ message: 'Project not found.' });
+  }
+
+  const placeholders = parsed.data.assetIds.map(() => '?').join(', ');
+  const now = new Date().toISOString();
+
+  const transaction = db.transaction(() => {
+    const deleteStatement = db.prepare(
+      `DELETE FROM project_assets WHERE project_id = ? AND id IN (${placeholders})`,
+    );
+    const result = deleteStatement.run(projectId, ...parsed.data.assetIds);
+    if (result.changes > 0) {
+      touchProjectStatement.run(now, projectId, userId);
+    }
+  });
+
+  try {
+    transaction();
+  } catch (error: unknown) {
+    console.error('Failed to remove project assets', error);
+    return res.status(500).json({ message: 'Could not remove assets. Please try again.' });
+  }
+
+  const project = loadProject(projectId, userId);
+  if (!project) {
+    return res.status(500).json({ message: 'Project could not be loaded after removing assets.' });
+  }
+
+  return res.json({ project });
+});
+
 app.use((_req, res) => {
   res.status(404).json({ message: 'Not found.' });
 });
 
-app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+app.use((err: unknown, _req: Request, res: Response) => {
   console.error('Unhandled error', err);
   res.status(500).json({ message: 'An unexpected error occurred.' });
 });

--- a/src/components/ImageAssetBrowser.tsx
+++ b/src/components/ImageAssetBrowser.tsx
@@ -6,8 +6,8 @@ interface ImageAssetBrowserProps {
   open: boolean;
   assets: ProjectAsset[];
   onClose: () => void;
-  onAddAssets: (assets: AssetInput[]) => void;
-  onRemoveAssets: (assetIds: string[]) => void;
+  onAddAssets: (assets: AssetInput[]) => void | Promise<void>;
+  onRemoveAssets: (assetIds: string[]) => void | Promise<void>;
   onLocateAsset: (assetId: string) => void;
 }
 
@@ -17,7 +17,7 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
 
   const previewAsset = useMemo(() => assets.find((asset) => asset.id === previewAssetId) ?? null, [assets, previewAssetId]);
 
-  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
 
     if (files.length === 0) {
@@ -29,7 +29,14 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
       url: URL.createObjectURL(file),
     }));
 
-    onAddAssets(mapped);
+    try {
+      const result = onAddAssets(mapped);
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        await result;
+      }
+    } catch (error) {
+      console.error('Failed to add assets', error);
+    }
     event.target.value = '';
   };
 
@@ -60,9 +67,17 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
     }
   }, [onLocateAsset, selectedAssets]);
 
-  const handleRemoveSelected = useCallback(() => {
+  const handleRemoveSelected = useCallback(async () => {
     if (selectedAssets.length > 0) {
-      onRemoveAssets(selectedAssets);
+      try {
+        const result = onRemoveAssets(selectedAssets);
+        if (result && typeof (result as Promise<unknown>).then === 'function') {
+          await result;
+        }
+        setSelectedAssets([]);
+      } catch (error) {
+        console.error('Failed to remove assets', error);
+      }
     }
   }, [onRemoveAssets, selectedAssets]);
 

--- a/src/components/NewItemDialog.tsx
+++ b/src/components/NewItemDialog.tsx
@@ -6,7 +6,7 @@ import { ITEM_TYPE_DEFINITIONS } from '../constants/itemOptions';
 interface NewItemDialogProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (item: ItemInput) => void;
+  onSubmit: (item: ItemInput) => void | Promise<void>;
 }
 
 const defaultState = {
@@ -28,7 +28,7 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
     setFormState(defaultState);
   };
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const trimmedName = formState.name.trim();
@@ -36,18 +36,26 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
       return;
     }
 
-    onSubmit({
-      name: trimmedName,
-      type: formState.itemType,
-      variant: formState.variant,
-      customDetails:
-        formState.variant.toLowerCase().includes('custom') || formState.itemType === 'custom'
-          ? formState.customDetails.trim() || undefined
-          : undefined,
-    });
+    try {
+      const result = onSubmit({
+        name: trimmedName,
+        type: formState.itemType,
+        variant: formState.variant,
+        customDetails:
+          formState.variant.toLowerCase().includes('custom') || formState.itemType === 'custom'
+            ? formState.customDetails.trim() || undefined
+            : undefined,
+      });
 
-    resetForm();
-    onClose();
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        await result;
+      }
+
+      resetForm();
+      onClose();
+    } catch (error) {
+      console.error('Failed to add item', error);
+    }
   };
 
   const handleClose = () => {

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -6,7 +6,7 @@ import { ITEM_TYPE_DEFINITIONS } from '../constants/itemOptions';
 interface NewProjectDialogProps {
   open: boolean;
   onClose: () => void;
-  onCreate: (data: { name: string; initialItem?: ItemInput }) => void;
+  onCreate: (data: { name: string; initialItem?: ItemInput }) => void | Promise<void>;
 }
 
 const emptyFormState = {
@@ -39,7 +39,7 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
     }));
   }, [typeDefinition]);
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const trimmedName = formState.name.trim();
@@ -62,11 +62,20 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
       };
     }
 
-    onCreate({
-      name: trimmedName,
-      initialItem,
-    });
-    onClose();
+    try {
+      const result = onCreate({
+        name: trimmedName,
+        initialItem,
+      });
+
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        await result;
+      }
+
+      onClose();
+    } catch (error) {
+      console.error('Failed to create project', error);
+    }
   };
 
   const showCustomField =

--- a/src/components/ProjectOverviewPanel.tsx
+++ b/src/components/ProjectOverviewPanel.tsx
@@ -7,13 +7,13 @@ interface ProjectOverviewPanelProps {
   projects: Project[];
   onOpenProject: (projectId: string) => void;
   onCreateProject: () => void;
-  onToggleFavorite: (projectId: string) => void;
+  onToggleFavorite: (projectId: string) => void | Promise<void>;
 }
 
 interface ProjectCardProps {
   project: Project;
   onOpenProject: (projectId: string) => void;
-  onToggleFavorite: (projectId: string) => void;
+  onToggleFavorite: (projectId: string) => void | Promise<void>;
 }
 
 const relativeTimeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
@@ -52,7 +52,7 @@ const ProjectCard = memo(({ project, onOpenProject, onToggleFavorite }: ProjectC
   const handleToggleFavorite = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
-      onToggleFavorite(project.id);
+      void onToggleFavorite(project.id);
     },
     [onToggleFavorite, project.id],
   );

--- a/src/context/ProjectContext.tsx
+++ b/src/context/ProjectContext.tsx
@@ -1,4 +1,7 @@
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import { apiFetch } from '../lib/api';
+import { useAuth } from './AuthContext';
 
 export type ProjectItemType = 'board' | 'cardDeck' | 'questPoster' | 'custom';
 
@@ -44,197 +47,167 @@ export interface AssetInput {
 
 interface ProjectContextValue {
   projects: Project[];
-  createProject: (input: NewProjectInput) => Project;
-  updateProjectName: (projectId: string, name: string) => void;
-  addItemToProject: (projectId: string, item: ItemInput) => ProjectItem | null;
-  addAssetsToProject: (projectId: string, assets: AssetInput[]) => ProjectAsset[];
-  removeAssetsFromProject: (projectId: string, assetIds: string[]) => void;
-  toggleFavorite: (projectId: string) => void;
+  loading: boolean;
+  refreshProjects: () => Promise<void>;
+  createProject: (input: NewProjectInput) => Promise<Project>;
+  updateProjectName: (projectId: string, name: string) => Promise<void>;
+  addItemToProject: (projectId: string, item: ItemInput) => Promise<ProjectItem | null>;
+  addAssetsToProject: (projectId: string, assets: AssetInput[]) => Promise<ProjectAsset[]>;
+  removeAssetsFromProject: (projectId: string, assetIds: string[]) => Promise<void>;
+  toggleFavorite: (projectId: string) => Promise<void>;
 }
 
 const ProjectContext = createContext<ProjectContextValue | undefined>(undefined);
 
-const createId = () => crypto.randomUUID();
-
-const createTimestamp = (offsetMs: number) => new Date(Date.now() - offsetMs).toISOString();
-
-const initialProjects: Project[] = [
-  {
-    id: createId(),
-    name: 'Mystic Realms Board Game',
-    items: [
-      {
-        id: createId(),
-        name: 'Realm Exploration Board',
-        type: 'board',
-        variant: 'Large (36 × 36 in)',
-      },
-      {
-        id: createId(),
-        name: 'Quest Reference Cards',
-        type: 'cardDeck',
-        variant: 'Tarot (2.75 × 4.75 in)',
-      },
-    ],
-    assets: [
-      {
-        id: createId(),
-        name: 'Forest Illustration',
-        url: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=600&q=60',
-      },
-      {
-        id: createId(),
-        name: 'Quest Icon Set',
-        url: 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=600&q=60',
-      },
-    ],
-    updatedAt: createTimestamp(1000 * 60 * 60 * 5),
-    favorite: false,
-  },
-  {
-    id: createId(),
-    name: 'Galactic Outpost Adventure',
-    items: [
-      {
-        id: createId(),
-        name: 'Mission Brief Posters',
-        type: 'questPoster',
-        variant: 'A3 (297 × 420 mm)',
-      },
-    ],
-    assets: [
-      {
-        id: createId(),
-        name: 'Star Map Texture',
-        url: 'https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?auto=format&fit=crop&w=600&q=60',
-      },
-    ],
-    updatedAt: createTimestamp(1000 * 60 * 60 * 24 * 3),
-    favorite: false,
-  },
-];
-
 export function ProjectProvider({ children }: { children: React.ReactNode }) {
-  const [projects, setProjects] = useState<Project[]>(initialProjects);
+  const { user } = useAuth();
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(false);
 
-  const withUpdatedTimestamp = (project: Project): Project => ({
-    ...project,
-    updatedAt: new Date().toISOString(),
-  });
+  const fetchProjects = useCallback(async () => {
+    if (!user) {
+      setProjects([]);
+      setLoading(false);
+      return;
+    }
 
-  const createProject = (input: NewProjectInput) => {
-    const projectId = createId();
-    const items: ProjectItem[] = input.initialItem
-      ? [
-          {
-            id: createId(),
-            name: input.initialItem.name,
-            type: input.initialItem.type,
-            variant: input.initialItem.variant,
-            customDetails: input.initialItem.customDetails,
-          },
-        ]
-      : [];
+    setLoading(true);
+    try {
+      const data = await apiFetch<{ projects: Project[] }>('/api/projects', { method: 'GET' });
+      setProjects(data.projects);
+    } catch (error) {
+      console.error('Failed to load projects', error);
+      setProjects([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
 
-    const newProject: Project = {
-      id: projectId,
-      name: input.name,
-      items,
-      assets: [],
-      updatedAt: new Date().toISOString(),
-      favorite: false,
-    };
+  useEffect(() => {
+    if (!user) {
+      setProjects([]);
+      setLoading(false);
+      return;
+    }
 
-    setProjects((prev) => [...prev, newProject]);
-    return newProject;
-  };
+    void fetchProjects();
+  }, [fetchProjects, user]);
 
-  const updateProjectName = (projectId: string, name: string) => {
-    setProjects((prev) =>
-      prev.map((project) =>
-        project.id === projectId
-          ? withUpdatedTimestamp({
-              ...project,
-              name,
-            })
-          : project,
-      ),
-    );
-  };
+  const createProject = useCallback(
+    async (input: NewProjectInput) => {
+      if (!user) {
+        throw new Error('You must be signed in to create projects.');
+      }
 
-  const addItemToProject = (projectId: string, item: ItemInput) => {
-    const newItem: ProjectItem = {
-      id: createId(),
-      name: item.name,
-      type: item.type,
-      variant: item.variant,
-      customDetails: item.customDetails,
-    };
+      const data = await apiFetch<{ project: Project }>('/api/projects', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      });
 
-    setProjects((prev) =>
-      prev.map((project) =>
-        project.id === projectId
-          ? withUpdatedTimestamp({
-              ...project,
-              items: [...project.items, newItem],
-            })
-          : project,
-      ),
-    );
+      setProjects((prev) => [...prev, data.project]);
+      return data.project;
+    },
+    [user],
+  );
 
-    return newItem;
-  };
+  const updateProjectName = useCallback(
+    async (projectId: string, name: string) => {
+      if (!user) {
+        throw new Error('You must be signed in to update projects.');
+      }
 
-  const addAssetsToProject = (projectId: string, assets: AssetInput[]) => {
-    const mappedAssets: ProjectAsset[] = assets.map((asset) => ({
-      id: createId(),
-      name: asset.name,
-      url: asset.url,
-    }));
+      const data = await apiFetch<{ project: Project }>(`/api/projects/${projectId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ name }),
+      });
 
-    setProjects((prev) =>
-      prev.map((project) =>
-        project.id === projectId
-          ? withUpdatedTimestamp({
-              ...project,
-              assets: [...project.assets, ...mappedAssets],
-            })
-          : project,
-      ),
-    );
+      setProjects((prev) => prev.map((project) => (project.id === projectId ? data.project : project)));
+    },
+    [user],
+  );
 
-    return mappedAssets;
-  };
+  const addItemToProject = useCallback(
+    async (projectId: string, item: ItemInput) => {
+      if (!user) {
+        throw new Error('You must be signed in to update projects.');
+      }
 
-  const removeAssetsFromProject = (projectId: string, assetIds: string[]) => {
-    setProjects((prev) =>
-      prev.map((project) =>
-        project.id === projectId
-          ? withUpdatedTimestamp({
-              ...project,
-              assets: project.assets.filter((asset) => !assetIds.includes(asset.id)),
-            })
-          : project,
-      ),
-    );
-  };
+      const data = await apiFetch<{ item: ProjectItem | null; project: Project }>(
+        `/api/projects/${projectId}/items`,
+        {
+          method: 'POST',
+          body: JSON.stringify(item),
+        },
+      );
 
-  const toggleFavorite = (projectId: string) => {
-    setProjects((prev) =>
-      prev.map((project) =>
-        project.id === projectId
-          ? {
-              ...project,
-              favorite: !project.favorite,
-            }
-          : project,
-      ),
-    );
-  };
+      setProjects((prev) => prev.map((project) => (project.id === projectId ? data.project : project)));
+      return data.item ?? null;
+    },
+    [user],
+  );
+
+  const addAssetsToProject = useCallback(
+    async (projectId: string, assets: AssetInput[]) => {
+      if (!user) {
+        throw new Error('You must be signed in to update projects.');
+      }
+
+      const data = await apiFetch<{ assets: ProjectAsset[]; project: Project }>(
+        `/api/projects/${projectId}/assets`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ assets }),
+        },
+      );
+
+      setProjects((prev) => prev.map((project) => (project.id === projectId ? data.project : project)));
+      return data.assets;
+    },
+    [user],
+  );
+
+  const removeAssetsFromProject = useCallback(
+    async (projectId: string, assetIds: string[]) => {
+      if (!user) {
+        throw new Error('You must be signed in to update projects.');
+      }
+
+      const data = await apiFetch<{ project: Project }>(`/api/projects/${projectId}/assets`, {
+        method: 'DELETE',
+        body: JSON.stringify({ assetIds }),
+      });
+
+      setProjects((prev) => prev.map((project) => (project.id === projectId ? data.project : project)));
+    },
+    [user],
+  );
+
+  const toggleFavorite = useCallback(
+    async (projectId: string) => {
+      if (!user) {
+        throw new Error('You must be signed in to update projects.');
+      }
+
+      const target = projects.find((project) => project.id === projectId);
+      if (!target) {
+        throw new Error('Project not found.');
+      }
+
+      const data = await apiFetch<{ project: Project }>(`/api/projects/${projectId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ favorite: !target.favorite }),
+      });
+
+      setProjects((prev) => prev.map((project) => (project.id === projectId ? data.project : project)));
+    },
+    [projects, user],
+  );
 
   const value = useMemo(
     () => ({
       projects,
+      loading,
+      refreshProjects: fetchProjects,
       createProject,
       updateProjectName,
       addItemToProject,
@@ -242,7 +215,17 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
       removeAssetsFromProject,
       toggleFavorite,
     }),
-    [projects],
+    [
+      addAssetsToProject,
+      addItemToProject,
+      createProject,
+      fetchProjects,
+      loading,
+      projects,
+      removeAssetsFromProject,
+      toggleFavorite,
+      updateProjectName,
+    ],
   );
 
   return <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,11 +12,11 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <ThemeProvider>
-        <ProjectProvider>
-          <AuthProvider>
+        <AuthProvider>
+          <ProjectProvider>
             <App />
-          </AuthProvider>
-        </ProjectProvider>
+          </ProjectProvider>
+        </AuthProvider>
       </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,10 +12,15 @@ function Home() {
   const [isDialogOpen, setDialogOpen] = useState(false);
 
   const handleCreateProject = useCallback(
-    ({ name, initialItem }: { name: string; initialItem?: ItemInput }) => {
-      const project = createProject({ name, initialItem });
-      setDialogOpen(false);
-      navigate(`/projects/${project.id}`);
+    async ({ name, initialItem }: { name: string; initialItem?: ItemInput }) => {
+      try {
+        const project = await createProject({ name, initialItem });
+        setDialogOpen(false);
+        navigate(`/projects/${project.id}`);
+      } catch (error) {
+        console.error('Failed to create project', error);
+        throw error;
+      }
     },
     [createProject, navigate],
   );
@@ -25,6 +30,17 @@ function Home() {
       navigate(`/projects/${projectId}`);
     },
     [navigate],
+  );
+
+  const handleToggleFavorite = useCallback(
+    async (projectId: string) => {
+      try {
+        await toggleFavorite(projectId);
+      } catch (error) {
+        console.error('Failed to toggle favorite', error);
+      }
+    },
+    [toggleFavorite],
   );
 
   const handleOpenDialog = useCallback(() => setDialogOpen(true), []);
@@ -52,7 +68,7 @@ function Home() {
           projects={projects}
           onOpenProject={handleOpenProject}
           onCreateProject={handleOpenDialog}
-          onToggleFavorite={toggleFavorite}
+          onToggleFavorite={handleToggleFavorite}
         />
       </section>
 

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -8,9 +8,9 @@ import { findProject, useProjects } from '../context/ProjectContext';
 
 const emptyAssetBrowserHandlers = Object.freeze({
   onClose: () => undefined,
-  onAddAssets: (_assets: AssetInput[]) => undefined,
-  onRemoveAssets: (_assetIds: string[]) => undefined,
-  onLocateAsset: (_assetId: string) => undefined,
+  onAddAssets: () => undefined,
+  onRemoveAssets: () => undefined,
+  onLocateAsset: () => undefined,
 });
 
 function ProjectPage() {
@@ -88,7 +88,7 @@ function ProjectPage() {
   const handleOpenAssetBrowser = useCallback(() => setAssetBrowserOpen(true), []);
   const handleCloseAssetBrowser = useCallback(() => setAssetBrowserOpen(false), []);
 
-  const handleRename = useCallback(() => {
+  const handleRename = useCallback(async () => {
     if (!project) {
       return;
     }
@@ -100,43 +100,69 @@ function ProjectPage() {
       return;
     }
 
-    updateProjectName(project.id, trimmed);
-    setEditingTitle(false);
-    setStatusMessage('Project name updated');
+    try {
+      await updateProjectName(project.id, trimmed);
+      setEditingTitle(false);
+      setStatusMessage('Project name updated');
+    } catch (error) {
+      console.error('Failed to update project name', error);
+      setStatusMessage((error as Error).message ?? 'Failed to update project name');
+    }
   }, [project, titleValue, updateProjectName]);
 
   const handleAddItem = useCallback(
-    (item: ItemInput) => {
+    async (item: ItemInput) => {
       if (!project) {
         return;
       }
 
-      addItemToProject(project.id, item);
-      setStatusMessage(`${item.name} added to ${project.name}`);
+      const projectName = project.name;
+
+      try {
+        const created = await addItemToProject(project.id, item);
+        const itemName = created?.name ?? item.name;
+        setStatusMessage(`${itemName} added to ${projectName}`);
+      } catch (error) {
+        console.error('Failed to add item to project', error);
+        setStatusMessage((error as Error).message ?? 'Failed to add item');
+      }
     },
     [addItemToProject, project],
   );
 
   const handleAddAssets = useCallback(
-    (assets: AssetInput[]) => {
+    async (assets: AssetInput[]) => {
       if (!project || assets.length === 0) {
         return;
       }
 
-      addAssetsToProject(project.id, assets);
-      setStatusMessage(`${assets.length} asset${assets.length === 1 ? '' : 's'} added to the library`);
+      try {
+        const added = await addAssetsToProject(project.id, assets);
+        const count = added.length;
+        if (count > 0) {
+          setStatusMessage(`${count} asset${count === 1 ? '' : 's'} added to the library`);
+        }
+      } catch (error) {
+        console.error('Failed to add assets to project', error);
+        setStatusMessage((error as Error).message ?? 'Failed to add assets');
+      }
     },
     [addAssetsToProject, project],
   );
 
   const handleRemoveAssets = useCallback(
-    (assetIds: string[]) => {
+    async (assetIds: string[]) => {
       if (!project || assetIds.length === 0) {
         return;
       }
 
-      removeAssetsFromProject(project.id, assetIds);
-      setStatusMessage(`${assetIds.length} asset${assetIds.length === 1 ? '' : 's'} deleted`);
+      try {
+        await removeAssetsFromProject(project.id, assetIds);
+        setStatusMessage(`${assetIds.length} asset${assetIds.length === 1 ? '' : 's'} deleted`);
+      } catch (error) {
+        console.error('Failed to remove assets from project', error);
+        setStatusMessage((error as Error).message ?? 'Failed to remove assets');
+      }
     },
     [project, removeAssetsFromProject],
   );
@@ -277,11 +303,13 @@ function ProjectPage() {
                 <input
                   value={titleValue}
                   onChange={(event) => setTitleValue(event.target.value)}
-                  onBlur={handleRename}
+                  onBlur={() => {
+                    void handleRename();
+                  }}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter') {
                       event.preventDefault();
-                      handleRename();
+                      void handleRename();
                     } else if (event.key === 'Escape') {
                       setTitleValue(project.name);
                       setEditingTitle(false);


### PR DESCRIPTION
## Summary
- add SQLite tables and REST endpoints to store projects, items, and assets per user
- load projects from the API in the React context and expose async mutations
- update the project overview, dialogs, and detail page to call the new APIs and drop demo data

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68dae46affd0832fbe0b575df2558cc8