### PR TITLE
Implement welcome flow and profile customizations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,56 @@
-import { Link, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
-import { useState } from 'react';
+import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { useCallback, useMemo } from 'react';
 
-import ThemeSwitcher from './components/ThemeSwitcher';
 import ProtectedRoute from './components/ProtectedRoute';
 import { useAuth } from './context/AuthContext';
 import Home from './pages/Home';
 import ProfilePage from './pages/ProfilePage';
 import ProjectPage from './pages/ProjectPage';
-import SignInPage from './pages/SignInPage';
-import SignUpPage from './pages/SignUpPage';
 import VerifyPage from './pages/VerifyPage';
+import AuthOverlay from './components/AuthOverlay';
 
 function App() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { user, signOut, initializing } = useAuth();
-  const [isSigningOut, setIsSigningOut] = useState(false);
+  const { user, initializing } = useAuth();
   const isProjectRoute = location.pathname.startsWith('/projects/');
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const authMode = searchParams.get('auth');
+  const redirectAfterAuth = searchParams.get('from') ?? undefined;
 
-  const handleSignOut = async () => {
-    setIsSigningOut(true);
-    try {
-      await signOut();
-      navigate('/');
-    } finally {
-      setIsSigningOut(false);
+  const openAuth = useCallback(
+    (mode: 'signin' | 'signup', options?: { from?: string }) => {
+      const params = new URLSearchParams(location.search);
+      params.set('auth', mode);
+      if (options?.from) {
+        params.set('from', options.from);
+      } else {
+        params.delete('from');
+      }
+
+      const search = params.toString();
+      navigate(`${location.pathname}${search ? `?${search}` : ''}`);
+    },
+    [location.pathname, location.search, navigate],
+  );
+
+  const closeAuth = useCallback(() => {
+    if (!authMode) {
+      return;
     }
-  };
+
+    const params = new URLSearchParams(location.search);
+    params.delete('auth');
+    params.delete('from');
+    const search = params.toString();
+    navigate(`${location.pathname}${search ? `?${search}` : ''}`, { replace: true });
+  }, [authMode, location.pathname, location.search, navigate]);
+
+  const handleAuthSuccess = useCallback(() => {
+    const destination = redirectAfterAuth ?? '/';
+    closeAuth();
+    navigate(destination, { replace: true });
+  }, [closeAuth, navigate, redirectAfterAuth]);
 
   return (
     <div className="flex min-h-screen flex-col bg-background font-sans text-text-primary">
@@ -37,38 +61,34 @@ function App() {
               Tabletop Creator – Your Friendly Game Design Companion
             </h1>
             <nav className="flex flex-col items-center justify-end gap-2 text-sm text-text-secondary sm:flex-row">
-              <Link to="/" className="rounded-full border border-border/70 px-3 py-1 font-medium uppercase tracking-wide text-text-secondary">
-                Starter Layout
-              </Link>
-              <ThemeSwitcher />
               <div className="flex items-center gap-3">
                 {initializing ? (
                   <span className="text-xs text-text-muted">Loading…</span>
                 ) : user ? (
-                  <>
-                    <Link to="/profile" className="font-medium text-accent underline-offset-2 hover:underline">
-                      Profile
-                    </Link>
-                    <button
-                      type="button"
-                      onClick={handleSignOut}
-                      disabled={isSigningOut}
-                      className="rounded border border-border px-3 py-1 text-xs font-medium text-text-secondary transition hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-70"
-                    >
-                      {isSigningOut ? 'Signing out…' : 'Log out'}
-                    </button>
-                  </>
+                  <button
+                    type="button"
+                    onClick={() => navigate('/profile')}
+                    className="relative inline-flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-border bg-surface-muted text-base font-semibold text-text-primary shadow-sm transition hover:border-accent hover:shadow-md"
+                  >
+                    <span className="uppercase">{user.email?.[0]?.toUpperCase() ?? 'U'}</span>
+                    <span className="sr-only">Open profile</span>
+                  </button>
                 ) : (
                   <>
-                    <Link to="/signin" className="font-medium text-accent underline-offset-2 hover:underline">
+                    <button
+                      type="button"
+                      onClick={() => openAuth('signin')}
+                      className="font-medium text-accent underline-offset-2 transition hover:underline"
+                    >
                       Sign in
-                    </Link>
-                    <Link
-                      to="/signup"
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => openAuth('signup')}
                       className="rounded bg-accent px-3 py-1 text-xs font-semibold text-text-inverse transition hover:bg-accent/90"
                     >
                       Sign up
-                    </Link>
+                    </button>
                   </>
                 )}
               </div>
@@ -77,18 +97,16 @@ function App() {
         </header>
       )}
 
-      <main
-        className={
-          isProjectRoute
-            ? 'flex flex-1 overflow-hidden'
-            : 'mx-auto flex w-full max-w-6xl flex-1 flex-col gap-16 px-6 py-12 sm:py-16'
-        }
-      >
+      <main className={isProjectRoute ? 'flex flex-1 overflow-hidden' : 'flex flex-1 flex-col'}>
         <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/signup" element={<SignUpPage />} />
-          <Route path="/signin" element={<SignInPage />} />
-          <Route path="/verify" element={<VerifyPage />} />
+          <Route
+            path="/"
+            element={<Home onOpenSignIn={() => openAuth('signin')} onOpenSignUp={() => openAuth('signup')} />}
+          />
+          <Route
+            path="/verify"
+            element={<VerifyPage onOpenSignIn={() => openAuth('signin')} onOpenSignUp={() => openAuth('signup')} />}
+          />
           <Route element={<ProtectedRoute />}>
             <Route path="/profile" element={<ProfilePage />} />
           </Route>
@@ -102,6 +120,15 @@ function App() {
           <p className="text-xs sm:text-sm">Crafted with Vite, React, TypeScript, and Tailwind CSS.</p>
         </div>
       </footer>
+
+      {authMode && (
+        <AuthOverlay
+          mode={authMode === 'signup' ? 'signup' : 'signin'}
+          onClose={closeAuth}
+          onSuccess={handleAuthSuccess}
+          onSwitch={(mode) => openAuth(mode, redirectAfterAuth ? { from: redirectAfterAuth } : undefined)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/AuthOverlay.tsx
+++ b/src/components/AuthOverlay.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+
+import SignInPanel from '../pages/SignInPage';
+import SignUpPanel from '../pages/SignUpPage';
+
+interface AuthOverlayProps {
+  mode: 'signin' | 'signup';
+  onClose: () => void;
+  onSuccess: () => void;
+  onSwitch: (mode: 'signin' | 'signup') => void;
+}
+
+export default function AuthOverlay({ mode, onClose, onSuccess, onSwitch }: AuthOverlayProps) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 py-6">
+      <div className="relative w-full max-w-md rounded-3xl border border-border/60 bg-surface px-6 py-8 shadow-2xl">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full border border-border/70 text-sm font-semibold text-text-secondary transition hover:border-accent hover:text-accent"
+        >
+          <span aria-hidden>×</span>
+          <span className="sr-only">Close</span>
+        </button>
+
+        {mode === 'signin' ? (
+          <SignInPanel onSuccess={onSuccess} onSwitch={() => onSwitch('signup')} />
+        ) : (
+          <SignUpPanel onSuccess={onSuccess} onSwitch={() => onSwitch('signin')} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -15,7 +15,15 @@ export default function ProtectedRoute() {
   }
 
   if (!user) {
-    return <Navigate to="/signin" replace state={{ from: location }} />;
+    const params = new URLSearchParams();
+    params.set('auth', 'signin');
+
+    const redirectPath = `${location.pathname}${location.search}`;
+    if (redirectPath && redirectPath !== '/') {
+      params.set('from', redirectPath);
+    }
+
+    return <Navigate to={`/?${params.toString()}`} replace />;
   }
 
   return <Outlet />;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,9 +5,16 @@ import ProjectOverviewPanel from '../components/ProjectOverviewPanel';
 import NewProjectDialog from '../components/NewProjectDialog';
 import { ItemInput } from '../context/ProjectContext';
 import { useProjects } from '../context/ProjectContext';
+import { useAuth } from '../context/AuthContext';
 
-function Home() {
+interface HomeProps {
+  onOpenSignIn: () => void;
+  onOpenSignUp: () => void;
+}
+
+function Home({ onOpenSignIn, onOpenSignUp }: HomeProps) {
   const navigate = useNavigate();
+  const { user } = useAuth();
   const { projects, createProject, toggleFavorite } = useProjects();
   const [isDialogOpen, setDialogOpen] = useState(false);
 
@@ -55,25 +62,49 @@ function Home() {
     [handleCloseDialog, handleCreateProject, isDialogOpen],
   );
 
-  return (
-    <>
-      <section className="flex flex-col gap-12">
-        <div className="flex flex-col items-center gap-6 text-center">
-          <h2 className="max-w-3xl text-balance text-4xl font-bold tracking-tight text-text-primary sm:text-5xl">
+  if (!user) {
+    return (
+      <div className="relative flex flex-1 items-center justify-center overflow-hidden">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-accent/20 via-surface-muted/40 to-transparent" />
+        <div className="relative z-10 mx-auto flex max-w-3xl flex-col items-center gap-8 px-6 py-16 text-center">
+          <h2 className="text-balance text-4xl font-bold tracking-tight text-text-primary sm:text-5xl">
             Unleash your creativity and bring your tabletop game ideas to life with ease!
           </h2>
+          <p className="max-w-2xl text-pretty text-base text-text-secondary sm:text-lg">
+            Start building custom boards, cards, and quests for your tabletop adventures with collaborative tools designed for storytellers.
+          </p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+            <button
+              type="button"
+              onClick={onOpenSignIn}
+              className="rounded-full border border-border px-6 py-3 text-sm font-semibold text-text-primary transition hover:border-accent hover:text-accent"
+            >
+              Sign in
+            </button>
+            <button
+              type="button"
+              onClick={onOpenSignUp}
+              className="rounded-full bg-accent px-6 py-3 text-sm font-semibold text-text-inverse shadow-sm transition hover:bg-accent/90"
+            >
+              Create your account
+            </button>
+          </div>
         </div>
+      </div>
+    );
+  }
 
-        <ProjectOverviewPanel
-          projects={projects}
-          onOpenProject={handleOpenProject}
-          onCreateProject={handleOpenDialog}
-          onToggleFavorite={handleToggleFavorite}
-        />
-      </section>
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-12 px-6 py-12 sm:py-16">
+      <ProjectOverviewPanel
+        projects={projects}
+        onOpenProject={handleOpenProject}
+        onCreateProject={handleOpenDialog}
+        onToggleFavorite={handleToggleFavorite}
+      />
 
       <NewProjectDialog {...dialogProps} />
-    </>
+    </div>
   );
 }
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,41 +1,348 @@
-import { Link } from 'react-router-dom';
+import { ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../context/AuthContext';
+import { useTheme } from '../context/ThemeContext';
+
+const NAV_ITEMS = [
+  {
+    id: 'profile',
+    label: 'User Profile',
+    description: 'Update your information and avatar.',
+  },
+  {
+    id: 'appearance',
+    label: 'Appearance',
+    description: 'Choose the theme that suits your world.',
+  },
+] as const;
+
+const PRESET_AVATARS = ['🐉', '🎲', '🧙', '🛡️', '🗺️', '⚔️'];
+
+type SectionId = (typeof NAV_ITEMS)[number]['id'];
+type AvatarState = { type: 'preset'; value: string } | { type: 'upload'; value: string };
+
+type SocialKey = 'website' | 'discord' | 'twitter';
 
 export default function ProfilePage() {
-  const { user } = useAuth();
+  const { user, signOut } = useAuth();
+  const navigate = useNavigate();
+  const { themeId, availableThemes, setThemeId } = useTheme();
+  const defaultName = useMemo(() => user?.email?.split('@')[0] ?? '', [user?.email]);
+  const [selectedSection, setSelectedSection] = useState<SectionId>('profile');
+  const [displayName, setDisplayName] = useState(defaultName);
+  const [bio, setBio] = useState('');
+  const [socialLinks, setSocialLinks] = useState<Record<SocialKey, string>>({
+    website: '',
+    discord: '',
+    twitter: '',
+  });
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [avatar, setAvatar] = useState<AvatarState>({ type: 'preset', value: PRESET_AVATARS[0] });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadedImage, setUploadedImage] = useState<string | null>(null);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  useEffect(() => {
+    setDisplayName(defaultName);
+  }, [defaultName]);
+
+  useEffect(() => {
+    if (!statusMessage) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setStatusMessage(null), 4000);
+    return () => window.clearTimeout(timeout);
+  }, [statusMessage]);
+
+  useEffect(() => {
+    return () => {
+      if (uploadedImage) {
+        URL.revokeObjectURL(uploadedImage);
+      }
+    };
+  }, [uploadedImage]);
 
   if (!user) {
     return null;
   }
 
+  const handleSocialChange = (key: SocialKey) => (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setSocialLinks((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleAvatarClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleAvatarUpload = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const previewUrl = URL.createObjectURL(file);
+    if (uploadedImage) {
+      URL.revokeObjectURL(uploadedImage);
+    }
+
+    setUploadedImage(previewUrl);
+    setAvatar({ type: 'upload', value: previewUrl });
+  };
+
+  const handlePresetAvatar = (icon: string) => {
+    if (uploadedImage) {
+      URL.revokeObjectURL(uploadedImage);
+      setUploadedImage(null);
+    }
+
+    setAvatar({ type: 'preset', value: icon });
+  };
+
+  const handleSaveProfile = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatusMessage('Your profile updates are saved for this session.');
+  };
+
+  const handleSignOut = async () => {
+    setIsSigningOut(true);
+    try {
+      await signOut();
+      navigate('/');
+    } finally {
+      setIsSigningOut(false);
+    }
+  };
+
+  const socialFields: { key: SocialKey; label: string; placeholder: string }[] = [
+    { key: 'website', label: 'Website', placeholder: 'https://example.com' },
+    { key: 'discord', label: 'Discord', placeholder: 'username#1234' },
+    { key: 'twitter', label: 'Twitter / X', placeholder: '@gamemaker' },
+  ];
+
   return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+    <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-10 px-6 py-12 sm:py-16">
       <header className="space-y-2">
-        <h2 className="text-3xl font-semibold text-text-primary">Your profile</h2>
-        <p className="text-sm text-text-secondary">This page is protected. Only signed-in users can see it.</p>
+        <h2 className="text-3xl font-semibold text-text-primary">Account</h2>
+        <p className="text-sm text-text-secondary">
+          Manage how you appear to other creators and fine-tune the app to match your style.
+        </p>
       </header>
 
-      <section className="rounded-lg border border-border bg-surface px-6 py-6 shadow-sm">
-        <dl className="grid grid-cols-1 gap-4 text-sm text-text-secondary">
-          <div className="flex flex-col gap-1">
-            <dt className="font-semibold text-text-primary">Email</dt>
-            <dd className="break-all text-text-secondary">{user.email}</dd>
-          </div>
-          <div className="flex flex-col gap-1">
-            <dt className="font-semibold text-text-primary">User ID</dt>
-            <dd className="text-xs text-text-muted">{user.id}</dd>
-          </div>
-        </dl>
-      </section>
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <aside className="flex w-full flex-col gap-3 lg:max-w-xs">
+          {NAV_ITEMS.map((item) => {
+            const isActive = selectedSection === item.id;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setSelectedSection(item.id)}
+                className={`w-full rounded-2xl border px-5 py-4 text-left transition ${
+                  isActive
+                    ? 'border-accent bg-surface shadow-sm'
+                    : 'border-border bg-surface-muted/60 hover:border-accent/60 hover:bg-surface'
+                }`}
+              >
+                <p className="text-base font-semibold text-text-primary">{item.label}</p>
+                <p className="mt-1 text-xs text-text-secondary">{item.description}</p>
+              </button>
+            );
+          })}
+        </aside>
 
-      <p className="text-sm text-text-secondary">
-        Head back to the{' '}
-        <Link to="/" className="font-medium text-accent underline-offset-2 hover:underline">
-          dashboard
-        </Link>{' '}
-        to continue designing.
-      </p>
+        <section className="flex-1 rounded-2xl border border-border bg-surface px-6 py-8 shadow-sm">
+          {selectedSection === 'profile' ? (
+            <div className="flex flex-col gap-8">
+              <div className="space-y-1">
+                <h3 className="text-xl font-semibold text-text-primary">Profile details</h3>
+                <p className="text-sm text-text-secondary">Tell others about your creative persona.</p>
+              </div>
+
+              <form onSubmit={handleSaveProfile} className="flex flex-col gap-8">
+                <div className="flex flex-col gap-6 md:flex-row md:items-center">
+                  <div className="flex flex-col items-center gap-3 md:items-start">
+                    <button
+                      type="button"
+                      onClick={handleAvatarClick}
+                      className="group relative flex h-32 w-32 items-center justify-center overflow-hidden rounded-full border border-border bg-surface-muted text-5xl shadow-sm transition hover:border-accent hover:shadow-lg"
+                    >
+                      {avatar.type === 'upload' ? (
+                        <img src={avatar.value} alt="Custom avatar" className="h-full w-full object-cover" />
+                      ) : (
+                        <span>{avatar.value}</span>
+                      )}
+                      <span className="absolute bottom-3 left-1/2 flex -translate-x-1/2 rounded-full bg-black/50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white opacity-0 transition group-hover:opacity-100">
+                        Change
+                      </span>
+                    </button>
+
+                    <div className="flex flex-wrap justify-center gap-2 md:justify-start">
+                      {PRESET_AVATARS.map((icon) => {
+                        const isCurrent = avatar.type === 'preset' && avatar.value === icon;
+                        return (
+                          <button
+                            key={icon}
+                            type="button"
+                            onClick={() => handlePresetAvatar(icon)}
+                            className={`inline-flex h-10 w-10 items-center justify-center rounded-full border text-xl transition ${
+                              isCurrent
+                                ? 'border-accent bg-accent/10 text-accent'
+                                : 'border-border text-text-secondary hover:border-accent/60 hover:text-accent'
+                            }`}
+                            aria-pressed={isCurrent}
+                          >
+                            <span>{icon}</span>
+                          </button>
+                        );
+                      })}
+                      <button
+                        type="button"
+                        onClick={handleAvatarClick}
+                        className="inline-flex items-center justify-center rounded-full border border-border px-3 py-2 text-xs font-semibold text-text-secondary transition hover:border-accent hover:text-accent"
+                      >
+                        Upload image
+                      </button>
+                    </div>
+
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={handleAvatarUpload}
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-1 text-center text-sm text-text-secondary md:text-left">
+                    <span className="font-semibold text-text-primary">Account email</span>
+                    <span className="break-all">{user.email}</span>
+                    <span className="text-xs text-text-muted">Used for sign in and important updates.</span>
+                  </div>
+                </div>
+
+                <div className="grid gap-6 md:grid-cols-2">
+                  <label className="flex flex-col gap-2 text-sm">
+                    <span className="font-medium text-text-secondary">Display name</span>
+                    <input
+                      type="text"
+                      value={displayName}
+                      onChange={(event) => setDisplayName(event.target.value)}
+                      placeholder="Call sign or alias"
+                      className="rounded border border-border bg-background px-3 py-2 text-base text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+                    />
+                  </label>
+
+                  <label className="md:col-span-2 flex flex-col gap-2 text-sm">
+                    <span className="font-medium text-text-secondary">Bio</span>
+                    <textarea
+                      value={bio}
+                      onChange={(event) => setBio(event.target.value)}
+                      rows={4}
+                      placeholder="Share a few sentences about your creative style."
+                      className="rounded border border-border bg-background px-3 py-2 text-base text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+                    />
+                    <span className="text-xs text-text-muted">This will appear on collaborative documents.</span>
+                  </label>
+                </div>
+
+                <div className="space-y-3">
+                  <h4 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">Social accounts</h4>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {socialFields.map((field) => (
+                      <label key={field.key} className="flex flex-col gap-2 text-sm">
+                        <span className="font-medium text-text-secondary">{field.label}</span>
+                        <input
+                          type="text"
+                          value={socialLinks[field.key]}
+                          onChange={handleSocialChange(field.key)}
+                          placeholder={field.placeholder}
+                          className="rounded border border-border bg-background px-3 py-2 text-base text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+                        />
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {statusMessage && <p className="text-sm font-semibold text-accent">{statusMessage}</p>}
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <button
+                    type="submit"
+                    className="inline-flex items-center justify-center rounded bg-accent px-5 py-2.5 text-sm font-semibold text-text-inverse transition hover:bg-accent/90"
+                  >
+                    Save changes
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={handleSignOut}
+                    disabled={isSigningOut}
+                    className="inline-flex items-center justify-center rounded border border-border px-5 py-2.5 text-sm font-semibold text-text-secondary transition hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    {isSigningOut ? 'Signing out…' : 'Sign out'}
+                  </button>
+                </div>
+              </form>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-6">
+              <div className="space-y-1">
+                <h3 className="text-xl font-semibold text-text-primary">Theme preferences</h3>
+                <p className="text-sm text-text-secondary">
+                  Pick a preset to instantly update the interface colors. Previews show how panels and accents will look.
+                </p>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                {availableThemes.map((theme) => {
+                  const isActive = themeId === theme.id;
+                  const backgroundGradient = `linear-gradient(135deg, ${theme.tokens['--color-background']}, ${
+                    theme.tokens['--color-surface-elevated'] ?? theme.tokens['--color-surface']
+                  })`;
+
+                  return (
+                    <button
+                      key={theme.id}
+                      type="button"
+                      onClick={() => setThemeId(theme.id)}
+                      className={`flex flex-col overflow-hidden rounded-2xl border text-left transition ${
+                        isActive ? 'border-accent ring-2 ring-accent/40' : 'border-border hover:border-accent/60'
+                      }`}
+                      aria-pressed={isActive}
+                    >
+                      <div className="relative h-28 w-full" style={{ background: backgroundGradient }}>
+                        <div
+                          className="absolute left-4 top-4 h-12 w-12 rounded-full shadow-lg"
+                          style={{ backgroundColor: theme.tokens['--color-accent'] }}
+                        />
+                        <div
+                          className="absolute bottom-4 right-4 h-3/4 w-1/3 rounded-lg border border-white/30 bg-white/20 backdrop-blur"
+                        />
+                      </div>
+                      <div className="flex items-center justify-between px-5 py-4">
+                        <div>
+                          <p className="text-base font-semibold text-text-primary">{theme.label}</p>
+                          <p className="text-xs uppercase tracking-wide text-text-secondary">
+                            {theme.colorScheme === 'dark' ? 'Dark theme' : 'Light theme'}
+                          </p>
+                        </div>
+                        {isActive && (
+                          <span className="rounded-full bg-accent/15 px-3 py-1 text-xs font-semibold text-accent">
+                            Active
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,19 +1,19 @@
 import { FormEvent, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../context/AuthContext';
 
-export default function SignInPage() {
+interface SignInPanelProps {
+  onSuccess?: () => void;
+  onSwitch?: () => void;
+}
+
+export default function SignInPage({ onSuccess, onSwitch }: SignInPanelProps) {
   const { signIn } = useAuth();
-  const navigate = useNavigate();
-  const location = useLocation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [isError, setIsError] = useState(false);
-
-  const fromPath = (location.state as { from?: { pathname?: string } } | undefined)?.from?.pathname ?? '/profile';
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -31,7 +31,7 @@ export default function SignInPage() {
       setIsError(!result.success);
       setMessage(result.message);
       if (result.success) {
-        navigate(fromPath, { replace: true });
+        onSuccess?.();
       }
     } finally {
       setIsSubmitting(false);
@@ -39,7 +39,7 @@ export default function SignInPage() {
   };
 
   return (
-    <div className="mx-auto flex w-full max-w-md flex-col gap-8">
+    <div className="flex w-full flex-col gap-8">
       <header className="space-y-2 text-center">
         <h2 className="text-3xl font-semibold text-text-primary">Welcome back</h2>
         <p className="text-sm text-text-secondary">Sign in to access your profile.</p>
@@ -89,9 +89,13 @@ export default function SignInPage() {
 
       <p className="text-center text-sm text-text-secondary">
         No account yet?{' '}
-        <Link to="/signup" className="font-medium text-accent underline-offset-2 hover:underline">
+        <button
+          type="button"
+          onClick={() => onSwitch?.()}
+          className="font-medium text-accent underline-offset-2 transition hover:underline"
+        >
           Create one now
-        </Link>
+        </button>
         .
       </p>
     </div>

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,10 +1,14 @@
 import { FormEvent, useState } from 'react';
-import { Link } from 'react-router-dom';
 
 import { useAuth } from '../context/AuthContext';
 
-export default function SignUpPage() {
-  const { signUp } = useAuth();
+interface SignUpPanelProps {
+  onSuccess?: () => void;
+  onSwitch?: () => void;
+}
+
+export default function SignUpPage({ onSuccess, onSwitch }: SignUpPanelProps) {
+  const { signUp, signIn } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -30,18 +34,30 @@ export default function SignUpPage() {
     setIsSubmitting(true);
     try {
       const result = await signUp({ email, password });
-      setIsError(!result.success);
-      setMessage(result.message);
-      if (result.success) {
-        setPassword('');
+      if (!result.success) {
+        setIsError(true);
+        setMessage(result.message);
+        return;
       }
+
+      setIsError(false);
+      setMessage('Account created! Signing you in…');
+
+      const loginResult = await signIn({ email, password });
+      if (loginResult.success) {
+        onSuccess?.();
+        return;
+      }
+
+      setIsError(true);
+      setMessage(loginResult.message);
     } finally {
       setIsSubmitting(false);
     }
   };
 
   return (
-    <div className="mx-auto flex w-full max-w-md flex-col gap-8">
+    <div className="flex w-full flex-col gap-8">
       <header className="space-y-2 text-center">
         <h2 className="text-3xl font-semibold text-text-primary">Create your account</h2>
         <p className="text-sm text-text-secondary">
@@ -94,9 +110,13 @@ export default function SignUpPage() {
 
       <p className="text-center text-sm text-text-secondary">
         Already have an account?{' '}
-        <Link to="/signin" className="font-medium text-accent underline-offset-2 hover:underline">
+        <button
+          type="button"
+          onClick={() => onSwitch?.()}
+          className="font-medium text-accent underline-offset-2 transition hover:underline"
+        >
           Sign in
-        </Link>
+        </button>
         .
       </p>
     </div>

--- a/src/pages/VerifyPage.tsx
+++ b/src/pages/VerifyPage.tsx
@@ -1,13 +1,37 @@
 import { useEffect, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { apiFetch } from '../lib/api';
 
-export default function VerifyPage() {
+interface VerifyPageProps {
+  onOpenSignIn?: () => void;
+  onOpenSignUp?: () => void;
+}
+
+export default function VerifyPage({ onOpenSignIn, onOpenSignUp }: VerifyPageProps) {
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>(token ? 'loading' : 'idle');
   const [message, setMessage] = useState<string>('');
+  const navigate = useNavigate();
+
+  const handleOpenSignIn = () => {
+    if (onOpenSignIn) {
+      onOpenSignIn();
+      return;
+    }
+
+    navigate('/?auth=signin');
+  };
+
+  const handleOpenSignUp = () => {
+    if (onOpenSignUp) {
+      onOpenSignUp();
+      return;
+    }
+
+    navigate('/?auth=signup');
+  };
 
   useEffect(() => {
     if (!token) {
@@ -48,12 +72,20 @@ export default function VerifyPage() {
       )}
 
       <div className="flex flex-col gap-2 text-sm text-text-secondary">
-        <Link to="/signin" className="font-medium text-accent underline-offset-2 hover:underline">
+        <button
+          type="button"
+          onClick={handleOpenSignIn}
+          className="font-medium text-accent underline-offset-2 transition hover:underline"
+        >
           Go to sign in
-        </Link>
-        <Link to="/signup" className="font-medium text-accent/80 underline-offset-2 hover:underline">
+        </button>
+        <button
+          type="button"
+          onClick={handleOpenSignUp}
+          className="font-medium text-accent/80 underline-offset-2 transition hover:underline"
+        >
           Need a new account?
-        </Link>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace the landing experience with a full-screen welcome view for signed-out users and launch auth overlays from the header
- convert sign-in and sign-up into modal panels that maintain redirect context and clean up the protected route flow
- redesign the profile page with avatar selection, editable details, and theme previews, and expose appearance settings via a sidebar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daeff09550832fa8caa6430d8e602f