### PR TITLE
Add reusable modal transitions and segmented control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,14 +121,13 @@ function App() {
         </div>
       </footer>
 
-      {authMode && (
-        <AuthOverlay
-          mode={authMode === 'signup' ? 'signup' : 'signin'}
-          onClose={closeAuth}
-          onSuccess={handleAuthSuccess}
-          onSwitch={(mode) => openAuth(mode, redirectAfterAuth ? { from: redirectAfterAuth } : undefined)}
-        />
-      )}
+      <AuthOverlay
+        open={Boolean(authMode)}
+        mode={authMode === 'signup' ? 'signup' : 'signin'}
+        onClose={closeAuth}
+        onSuccess={handleAuthSuccess}
+        onSwitch={(mode) => openAuth(mode, redirectAfterAuth ? { from: redirectAfterAuth } : undefined)}
+      />
     </div>
   );
 }

--- a/src/components/AuthOverlay.tsx
+++ b/src/components/AuthOverlay.tsx
@@ -1,45 +1,58 @@
-import { useEffect } from 'react';
+import { useEffect, useId, useRef } from 'react';
 
 import SignInPanel from '../pages/SignInPage';
 import SignUpPanel from '../pages/SignUpPage';
+import CloseButton from './CloseButton';
+import ModalTransition from './ModalTransition';
 
 interface AuthOverlayProps {
+  open: boolean;
   mode: 'signin' | 'signup';
   onClose: () => void;
   onSuccess: () => void;
   onSwitch: (mode: 'signin' | 'signup') => void;
 }
 
-export default function AuthOverlay({ mode, onClose, onSuccess, onSwitch }: AuthOverlayProps) {
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
+export default function AuthOverlay({ open, mode, onClose, onSuccess, onSwitch }: AuthOverlayProps) {
+  const titleId = useId();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  useEffect(() => {
+    if (open && firstFieldRef.current) {
+      firstFieldRef.current.focus({ preventScroll: true });
+    }
+  }, [mode, open]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 py-6">
-      <div className="relative w-full max-w-md rounded-3xl border border-border/60 bg-surface px-6 py-8 shadow-2xl">
-        <button
-          type="button"
-          onClick={onClose}
-          className="absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full border border-border/70 text-sm font-semibold text-text-secondary transition hover:border-accent hover:text-accent"
-        >
-          <span aria-hidden>×</span>
-          <span className="sr-only">Close</span>
-        </button>
+    <ModalTransition
+      open={open}
+      onClose={onClose}
+      labelledBy={titleId}
+      initialFocusRef={firstFieldRef}
+      overlayClassName="bg-black/60 px-4 py-6"
+      panelClassName="relative w-full max-w-md rounded-3xl border border-border/60 bg-surface px-6 py-8 shadow-2xl"
+    >
+      <CloseButton
+        onClick={onClose}
+        className="absolute right-4 top-4"
+        label={mode === 'signin' ? 'Close sign in dialog' : 'Close sign up dialog'}
+      />
 
-        {mode === 'signin' ? (
-          <SignInPanel onSuccess={onSuccess} onSwitch={() => onSwitch('signup')} />
-        ) : (
-          <SignUpPanel onSuccess={onSuccess} onSwitch={() => onSwitch('signin')} />
-        )}
-      </div>
-    </div>
+      {mode === 'signin' ? (
+        <SignInPanel
+          onSuccess={onSuccess}
+          onSwitch={() => onSwitch('signup')}
+          titleId={titleId}
+          initialFocusRef={firstFieldRef}
+        />
+      ) : (
+        <SignUpPanel
+          onSuccess={onSuccess}
+          onSwitch={() => onSwitch('signin')}
+          titleId={titleId}
+          initialFocusRef={firstFieldRef}
+        />
+      )}
+    </ModalTransition>
   );
 }

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+
+interface CloseButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label?: string;
+}
+
+const baseClasses =
+  'inline-flex h-10 w-10 items-center justify-center rounded-lg text-[#ef4444] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ef4444] hover:bg-[#fee2e2] active:bg-[#fecaca]';
+
+/**
+ * Standard close button for dismissible panels.
+ * Use together with {@link ModalTransition} so keyboard + pointer interactions stay consistent.
+ */
+const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(function CloseButton(
+  { label = 'Close panel', className, children, type = 'button', ...buttonProps },
+  ref,
+) {
+  const composedClassName = className ? `${baseClasses} ${className}` : baseClasses;
+
+  return (
+    <button ref={ref} type={type} className={composedClassName} aria-label={label} {...buttonProps}>
+      {children ?? (
+        <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M6.22 6.22a.75.75 0 0 1 1.06 0L12 10.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L13.06 12l4.72 4.72a.75.75 0 1 1-1.06 1.06L12 13.06l-4.72 4.72a.75.75 0 1 1-1.06-1.06L10.94 12 6.22 7.28a.75.75 0 0 1 0-1.06z"
+          />
+        </svg>
+      )}
+    </button>
+  );
+});
+
+export default CloseButton;

--- a/src/components/ImageAssetBrowser.tsx
+++ b/src/components/ImageAssetBrowser.tsx
@@ -1,6 +1,8 @@
-import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { AssetInput, ProjectAsset } from '../context/ProjectContext';
+import CloseButton from './CloseButton';
+import ModalTransition from './ModalTransition';
 
 interface ImageAssetBrowserProps {
   open: boolean;
@@ -14,6 +16,9 @@ interface ImageAssetBrowserProps {
 function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets, onLocateAsset }: ImageAssetBrowserProps) {
   const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
   const [previewAssetId, setPreviewAssetId] = useState<string | null>(null);
+
+  const headingId = useId();
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const previewAsset = useMemo(() => assets.find((asset) => asset.id === previewAssetId) ?? null, [assets, previewAssetId]);
 
@@ -87,128 +92,119 @@ function ImageAssetBrowser({ open, assets, onClose, onAddAssets, onRemoveAssets,
 
   const selectedCount = selectedAssets.length;
 
-  if (!open) {
-    return null;
-  }
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/80 p-6">
-      <div className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60">
-        <div className="flex items-center justify-between border-b border-border/70 px-8 py-6">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">Image Library</p>
-            <h2 className="mt-1 text-xl font-semibold text-text-primary">Manage your project visuals</h2>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={handleLocateSelected}
-              disabled={selectedCount !== 1}
-              className="rounded-full border border-border/70 px-4 py-2 text-xs font-semibold text-text-secondary transition disabled:cursor-not-allowed disabled:opacity-50 hover:border-accent hover:text-accent/80"
-            >
-              Locate usage
-            </button>
-            <button
-              type="button"
-              onClick={handleRemoveSelected}
-              disabled={selectedCount === 0}
-              className="rounded-full border border-rose-500/60 px-4 py-2 text-xs font-semibold text-rose-200 transition disabled:cursor-not-allowed disabled:opacity-50 hover:bg-rose-500/10"
-            >
-              Delete selected
-            </button>
-            <label className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-accent px-4 py-2 text-xs font-semibold text-accent-contrast transition hover:bg-accent-strong">
-              <input type="file" accept="image/*" multiple className="hidden" onChange={handleFileChange} />
-              Add images
-            </label>
-            <button
-              type="button"
-              onClick={clearStateAndClose}
-              className="flex h-9 w-9 items-center justify-center rounded-full border border-border/70 text-text-secondary transition hover:border-accent hover:text-text-primary"
-              aria-label="Close image library"
-            >
-              <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
-                <path
-                  fill="currentColor"
-                  d="M6.22 6.22a.75.75 0 011.06 0L12 10.94l4.72-4.72a.75.75 0 111.06 1.06L13.06 12l4.72 4.72a.75.75 0 11-1.06 1.06L12 13.06l-4.72 4.72a.75.75 0 11-1.06-1.06L10.94 12 6.22 7.28a.75.75 0 010-1.06z"
-                />
-              </svg>
-            </button>
-          </div>
+    <ModalTransition
+      open={open}
+      onClose={clearStateAndClose}
+      labelledBy={headingId}
+      initialFocusRef={closeButtonRef}
+      overlayClassName="bg-overlay/80 p-6"
+      panelClassName="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60"
+    >
+      <div className="flex items-center justify-between border-b border-border/70 px-8 py-6">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">Image Library</p>
+          <h2 id={headingId} className="mt-1 text-xl font-semibold text-text-primary">
+            Manage your project visuals
+          </h2>
         </div>
-
-        <div className="flex flex-1 overflow-hidden">
-          <div className="flex-1 overflow-y-auto px-8 py-6">
-            {assets.length === 0 ? (
-              <div className="flex h-full flex-col items-center justify-center rounded-2xl border border-dashed border-border/70 bg-surface-muted/50 p-12 text-center">
-                <p className="text-lg font-semibold text-text-secondary">No images yet</p>
-                <p className="mt-2 max-w-md text-sm text-text-muted">
-                  Use the "Add images" button to import concept art, icons, or reference boards for this project.
-                </p>
-              </div>
-            ) : (
-              <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
-                {assets.map((asset) => {
-                  const selected = selectedAssets.includes(asset.id);
-                  return (
-                    <div
-                      key={asset.id}
-                      className={`group relative overflow-hidden rounded-2xl border transition ${
-                        selected ? 'border-accent/70' : 'border-border/80'
-                      }`}
-                    >
-                      <button
-                        type="button"
-                        onClick={() => handlePreview(asset.id)}
-                        className="relative block h-40 w-full overflow-hidden bg-surface-muted/80"
-                      >
-                        <img
-                          src={asset.url}
-                          alt={asset.name}
-                          loading="lazy"
-                          decoding="async"
-                          className="h-full w-full object-cover transition duration-300 will-change-transform group-hover:scale-105"
-                        />
-                      </button>
-                      <div className="flex items-center justify-between gap-2 border-t border-border/80 bg-surface-muted/80 px-3 py-3">
-                        <p className="truncate text-xs font-semibold text-text-secondary" title={asset.name}>
-                          {asset.name}
-                        </p>
-                        <button
-                          type="button"
-                          onClick={() => toggleSelected(asset.id)}
-                          className={`flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold transition ${
-                            selected
-                              ? 'border-accent/70 bg-accent/20 text-accent/80'
-                              : 'border-border/70 text-text-secondary hover:border-accent hover:text-accent/80'
-                          }`}
-                        >
-                          {selected ? '✓' : '+'}
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-
-          <div className="hidden w-64 border-l border-border/80 bg-surface-elevated/90 p-6 lg:block">
-            <h3 className="text-sm font-semibold text-text-secondary">Preview</h3>
-            {previewAsset ? (
-              <div className="mt-4 space-y-3">
-                <div className="overflow-hidden rounded-xl border border-border/80">
-                  <img src={previewAsset.url} alt={previewAsset.name} className="w-full" />
-                </div>
-                <p className="text-xs uppercase tracking-[0.3em] text-text-muted">Title</p>
-                <p className="text-sm font-semibold text-text-primary">{previewAsset.name}</p>
-              </div>
-            ) : (
-              <p className="mt-4 text-xs text-text-muted">Select an asset to see a larger preview.</p>
-            )}
-          </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleLocateSelected}
+            disabled={selectedCount !== 1}
+            className="rounded-full border border-border/70 px-4 py-2 text-xs font-semibold text-text-secondary transition disabled:cursor-not-allowed disabled:opacity-50 hover:border-accent hover:text-accent/80"
+          >
+            Locate usage
+          </button>
+          <button
+            type="button"
+            onClick={handleRemoveSelected}
+            disabled={selectedCount === 0}
+            className="rounded-full border border-rose-500/60 px-4 py-2 text-xs font-semibold text-rose-200 transition disabled:cursor-not-allowed disabled:opacity-50 hover:bg-rose-500/10"
+          >
+            Delete selected
+          </button>
+          <label className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-accent px-4 py-2 text-xs font-semibold text-accent-contrast transition hover:bg-accent-strong">
+            <input type="file" accept="image/*" multiple className="hidden" onChange={handleFileChange} />
+            Add images
+          </label>
+          <CloseButton ref={closeButtonRef} onClick={clearStateAndClose} label="Close image library" className="ml-1 shrink-0" />
         </div>
       </div>
-    </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex-1 overflow-y-auto px-8 py-6">
+          {assets.length === 0 ? (
+            <div className="flex h-full flex-col items-center justify-center rounded-2xl border border-dashed border-border/70 bg-surface-muted/50 p-12 text-center">
+              <p className="text-lg font-semibold text-text-secondary">No images yet</p>
+              <p className="mt-2 max-w-md text-sm text-text-muted">
+                Use the "Add images" button to import concept art, icons, or reference boards for this project.
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+              {assets.map((asset) => {
+                const selected = selectedAssets.includes(asset.id);
+                return (
+                  <div
+                    key={asset.id}
+                    className={`group relative overflow-hidden rounded-2xl border transition ${
+                      selected ? 'border-accent/70' : 'border-border/80'
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => handlePreview(asset.id)}
+                      className="relative block h-40 w-full overflow-hidden bg-surface-muted/80"
+                    >
+                      <img
+                        src={asset.url}
+                        alt={asset.name}
+                        loading="lazy"
+                        decoding="async"
+                        className="h-full w-full object-cover transition duration-300 will-change-transform group-hover:scale-105"
+                      />
+                    </button>
+                    <div className="flex items-center justify-between gap-2 border-t border-border/80 bg-surface-muted/80 px-3 py-3">
+                      <p className="truncate text-xs font-semibold text-text-secondary" title={asset.name}>
+                        {asset.name}
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => toggleSelected(asset.id)}
+                        className={`flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold transition ${
+                          selected
+                            ? 'border-accent/70 bg-accent/20 text-accent/80'
+                            : 'border-border/70 text-text-secondary hover:border-accent hover:text-accent/80'
+                        }`}
+                      >
+                        {selected ? '✓' : '+'}
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="hidden w-64 border-l border-border/80 bg-surface-elevated/90 p-6 lg:block">
+          <h3 className="text-sm font-semibold text-text-secondary">Preview</h3>
+          {previewAsset ? (
+            <div className="mt-4 space-y-3">
+              <div className="overflow-hidden rounded-xl border border-border/80">
+                <img src={previewAsset.url} alt={previewAsset.name} className="w-full" />
+              </div>
+              <p className="text-xs uppercase tracking-[0.3em] text-text-muted">Title</p>
+              <p className="text-sm font-semibold text-text-primary">{previewAsset.name}</p>
+            </div>
+          ) : (
+            <p className="mt-4 text-xs text-text-muted">Select an asset to see a larger preview.</p>
+          )}
+        </div>
+      </div>
+    </ModalTransition>
   );
 }
 

--- a/src/components/ModalTransition.tsx
+++ b/src/components/ModalTransition.tsx
@@ -1,0 +1,215 @@
+import {
+  CSSProperties,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+import { usePrefersReducedMotion } from '../lib/usePrefersReducedMotion';
+
+interface ModalTransitionProps {
+  open: boolean;
+  onClose: () => void;
+  labelledBy: string;
+  children: ReactNode;
+  overlayClassName?: string;
+  panelClassName?: string;
+  /**
+   * When provided the modal will attempt to focus this element first.
+   * Useful for focusing the primary input or close button in a panel.
+   */
+  initialFocusRef?: React.RefObject<HTMLElement>;
+}
+
+type ModalPhase = 'exited' | 'entering' | 'entered' | 'exiting';
+
+const focusableSelector =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Shared transition + accessibility wrapper for pop-up panels.
+ * Wrap any modal content with this component to get consistent animation,
+ * focus trapping, ESC/backdrop dismissal, and reduced-motion handling.
+ */
+export default function ModalTransition({
+  open,
+  onClose,
+  labelledBy,
+  children,
+  overlayClassName,
+  panelClassName,
+  initialFocusRef,
+}: ModalTransitionProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [phase, setPhase] = useState<ModalPhase>(open ? 'entered' : 'exited');
+  const [shouldRender, setShouldRender] = useState<boolean>(open);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const pointerDownOnOverlay = useRef(false);
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+
+  const panelDuration = prefersReducedMotion ? 150 : 250;
+  const overlayDuration = prefersReducedMotion ? 140 : 200;
+  const easing = 'cubic-bezier(0.2, 0.8, 0.2, 1)';
+
+  useEffect(() => {
+    if (open) {
+      setShouldRender(true);
+      setPhase('entering');
+      const timer = window.setTimeout(() => {
+        setPhase('entered');
+      }, panelDuration);
+      return () => window.clearTimeout(timer);
+    }
+
+    if (phase === 'exited') {
+      return undefined;
+    }
+
+    setPhase('exiting');
+    const timer = window.setTimeout(() => {
+      setPhase('exited');
+      setShouldRender(false);
+    }, panelDuration);
+
+    return () => window.clearTimeout(timer);
+  }, [open, panelDuration, phase]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const panel = panelRef.current;
+      if (!panel) {
+        return;
+      }
+
+      const focusableElements = Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+        (element) => !element.hasAttribute('data-modal-focus-guard'),
+      );
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        panel.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (activeElement === firstElement || activeElement === panel) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+      } else if (activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!shouldRender) {
+      return undefined;
+    }
+
+    previouslyFocusedElement.current = document.activeElement as HTMLElement | null;
+
+    const panel = panelRef.current;
+    const focusTarget = initialFocusRef?.current ?? panel?.querySelector<HTMLElement>(focusableSelector) ?? panel;
+    focusTarget?.focus({ preventScroll: true });
+
+    document.addEventListener('keydown', handleKeyDown);
+    const { overflow: originalOverflow } = document.body.style;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = originalOverflow;
+
+      const previouslyFocused = previouslyFocusedElement.current;
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus({ preventScroll: true });
+      }
+      previouslyFocusedElement.current = null;
+    };
+  }, [shouldRender, handleKeyDown, initialFocusRef]);
+
+  const panelInlineStyles = useMemo(() => {
+    return {
+      '--modal-panel-duration': `${panelDuration}ms`,
+      '--modal-overlay-duration': `${overlayDuration}ms`,
+      '--modal-easing': easing,
+    } as CSSProperties;
+  }, [overlayDuration, panelDuration, easing]);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  const portalTarget = typeof document !== 'undefined' ? document.body : null;
+  if (!portalTarget) {
+    return null;
+  }
+
+  const stateAttribute = phase === 'entered' ? 'entered' : phase === 'entering' ? 'entering' : 'exiting';
+  const motionAttribute = prefersReducedMotion ? 'reduced' : 'standard';
+
+  const overlayClasses = overlayClassName ? `modal-overlay ${overlayClassName}` : 'modal-overlay';
+  const panelClasses = panelClassName ? `modal-panel ${panelClassName}` : 'modal-panel';
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.target === overlayRef.current) {
+      pointerDownOnOverlay.current = true;
+    }
+  };
+
+  const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (pointerDownOnOverlay.current && event.target === overlayRef.current) {
+      onClose();
+    }
+    pointerDownOnOverlay.current = false;
+  };
+
+  return createPortal(
+    <div
+      ref={overlayRef}
+      className={overlayClasses}
+      data-state={stateAttribute}
+      data-motion={motionAttribute}
+      style={panelInlineStyles}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelledBy}
+        tabIndex={-1}
+        className={panelClasses}
+        data-state={stateAttribute}
+        data-motion={motionAttribute}
+      >
+        {children}
+      </div>
+    </div>,
+    portalTarget,
+  );
+}

--- a/src/components/NewItemDialog.tsx
+++ b/src/components/NewItemDialog.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useMemo, useState } from 'react';
 
 import { ItemInput, ProjectItemType } from '../context/ProjectContext';
 import { ITEM_TYPE_DEFINITIONS } from '../constants/itemOptions';
+import CloseButton from './CloseButton';
 
 interface NewItemDialogProps {
   open: boolean;
@@ -78,19 +79,7 @@ function NewItemDialog({ open, onClose, onSubmit }: NewItemDialogProps) {
             <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">New Item</p>
             <h2 className="mt-2 text-xl font-semibold text-text-primary">Add to this project</h2>
           </div>
-          <button
-            type="button"
-            onClick={handleClose}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-border/70 text-text-secondary transition hover:border-accent hover:text-text-primary"
-            aria-label="Close"
-          >
-            <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
-              <path
-                fill="currentColor"
-                d="M6.22 6.22a.75.75 0 011.06 0L12 10.94l4.72-4.72a.75.75 0 111.06 1.06L13.06 12l4.72 4.72a.75.75 0 11-1.06 1.06L12 13.06l-4.72 4.72a.75.75 0 11-1.06-1.06L10.94 12 6.22 7.28a.75.75 0 010-1.06z"
-              />
-            </svg>
-          </button>
+          <CloseButton onClick={handleClose} label="Close new item dialog" className="ml-2 shrink-0" />
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6 px-6 py-5">

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useMemo, useState } from 'react';
 
 import { ItemInput, ProjectItemType } from '../context/ProjectContext';
 import { ITEM_TYPE_DEFINITIONS } from '../constants/itemOptions';
+import CloseButton from './CloseButton';
 
 interface NewProjectDialogProps {
   open: boolean;
@@ -93,19 +94,7 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
             <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">New Project</p>
             <h2 className="mt-2 text-2xl font-semibold text-text-primary">Create a tabletop adventure workspace</h2>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-border/70 text-text-secondary transition hover:border-accent hover:text-text-primary"
-            aria-label="Close"
-          >
-            <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
-              <path
-                fill="currentColor"
-                d="M6.22 6.22a.75.75 0 011.06 0L12 10.94l4.72-4.72a.75.75 0 111.06 1.06L13.06 12l4.72 4.72a.75.75 0 11-1.06 1.06L12 13.06l-4.72 4.72a.75.75 0 11-1.06-1.06L10.94 12 6.22 7.28a.75.75 0 010-1.06z"
-              />
-            </svg>
-          </button>
+          <CloseButton onClick={onClose} label="Close new project dialog" className="ml-2 shrink-0" />
         </div>
 
         <form onSubmit={handleSubmit} className="grid gap-8 px-8 py-6 sm:grid-cols-2">

--- a/src/components/ProjectOverviewPanel.tsx
+++ b/src/components/ProjectOverviewPanel.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 import type { KeyboardEvent, MouseEvent } from 'react';
 
 import { Project } from '../context/ProjectContext';
+import SegmentedControl from './SegmentedControl';
 
 interface ProjectOverviewPanelProps {
   projects: Project[];
@@ -135,10 +136,20 @@ function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject, onTogg
     return sortedProjects;
   }, [sortedProjects, sortMode]);
 
-  const handleSelectRecent = useCallback(() => setSortMode('recent'), []);
-  const handleSelectFavorites = useCallback(() => setSortMode('favorites'), []);
+  const handleSegmentChange = useCallback((segmentId: string) => {
+    if (segmentId === 'recent' || segmentId === 'favorites') {
+      setSortMode(segmentId);
+    }
+  }, []);
 
   const hasFavorites = useMemo(() => projects.some((project) => project.favorite), [projects]);
+  const segmentItems = useMemo(
+    () => [
+      { id: 'recent', label: 'Recent' },
+      { id: 'favorites', label: 'Favorites' },
+    ],
+    [],
+  );
 
   return (
     <section className="rounded-3xl border border-border bg-surface-muted/60 shadow-2xl shadow-black/40">
@@ -154,32 +165,12 @@ function ProjectOverviewPanel({ projects, onOpenProject, onCreateProject, onTogg
           </p>
         </div>
         <div className="flex flex-col items-stretch justify-end gap-3 sm:flex-row sm:items-center">
-          <div className="inline-flex items-center gap-2 rounded-full bg-surface/40 p-1">
-            <button
-              type="button"
-              onClick={handleSelectRecent}
-              className={`rounded-full px-4 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
-                sortMode === 'recent'
-                  ? 'bg-accent text-accent-contrast shadow-sm shadow-accent/40'
-                  : 'text-text-secondary hover:text-text-primary'
-              }`}
-              aria-pressed={sortMode === 'recent'}
-            >
-              Recent
-            </button>
-            <button
-              type="button"
-              onClick={handleSelectFavorites}
-              className={`rounded-full px-4 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
-                sortMode === 'favorites'
-                  ? 'bg-accent text-accent-contrast shadow-sm shadow-accent/40'
-                  : 'text-text-secondary hover:text-text-primary'
-              }`}
-              aria-pressed={sortMode === 'favorites'}
-            >
-              Favorites
-            </button>
-          </div>
+          <SegmentedControl
+            value={sortMode}
+            onChange={handleSegmentChange}
+            items={segmentItems}
+            ariaLabel="Filter projects by recency or favorites"
+          />
           <button
             type="button"
             onClick={onCreateProject}

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -1,0 +1,234 @@
+import {
+  CSSProperties,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { usePrefersReducedMotion } from '../lib/usePrefersReducedMotion';
+
+interface SegmentedControlItem {
+  id: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface SegmentedControlProps {
+  items: SegmentedControlItem[];
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  className?: string;
+  ariaLabel?: string;
+}
+
+const horizontalPadding = 32; // matches px-4 on each segment
+
+/**
+ * Accessible segmented control with equal-width segments and a sliding indicator.
+ * Provide `items`, `value`, and `onChange` to control the selection.
+ */
+export default function SegmentedControl({
+  items,
+  value,
+  onChange,
+  disabled = false,
+  className,
+  ariaLabel,
+}: SegmentedControlProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [segmentWidth, setSegmentWidth] = useState(0);
+  const measurementId = useId();
+  const measurementRef = useRef<HTMLDivElement | null>(null);
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const labelsKey = useMemo(() => items.map((item) => item.label).join('|'), [items]);
+
+  const recalculateWidth = useCallback(() => {
+    const measurementContainer = measurementRef.current;
+    if (!measurementContainer) {
+      return;
+    }
+
+    const spans = Array.from(measurementContainer.querySelectorAll('span[data-segment-measure]')) as HTMLSpanElement[];
+    if (spans.length === 0) {
+      return;
+    }
+
+    const maxLabelWidth = spans.reduce((max, span) => Math.max(max, span.getBoundingClientRect().width), 0);
+    setSegmentWidth(Math.ceil(maxLabelWidth) + horizontalPadding);
+  }, []);
+
+  useLayoutEffect(() => {
+    recalculateWidth();
+  }, [recalculateWidth, labelsKey]);
+
+  useEffect(() => {
+    if (!measurementRef.current) {
+      return undefined;
+    }
+
+    recalculateWidth();
+    window.addEventListener('resize', recalculateWidth);
+    return () => window.removeEventListener('resize', recalculateWidth);
+  }, [recalculateWidth, labelsKey]);
+
+  const activeIndex = Math.max(
+    0,
+    items.findIndex((item) => item.id === value && !item.disabled),
+  );
+
+  const moveSelection = useCallback(
+    (offset: number) => {
+      if (disabled || items.length === 0) {
+        return;
+      }
+
+      const startIndex = items.findIndex((item) => item.id === value);
+      let index = startIndex === -1 ? 0 : startIndex;
+
+      for (let step = 0; step < items.length; step += 1) {
+        index = (index + offset + items.length) % items.length;
+        const candidate = items[index];
+        if (!candidate.disabled) {
+          onChange(candidate.id);
+          requestAnimationFrame(() => buttonRefs.current[index]?.focus());
+          return;
+        }
+      }
+    },
+    [disabled, items, onChange, value],
+  );
+
+  const selectFirstEnabled = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+
+    const firstIndex = items.findIndex((item) => !item.disabled);
+    if (firstIndex !== -1) {
+      onChange(items[firstIndex].id);
+      requestAnimationFrame(() => buttonRefs.current[firstIndex]?.focus());
+    }
+  }, [disabled, items, onChange]);
+
+  const selectLastEnabled = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      if (!items[index]?.disabled) {
+        onChange(items[index].id);
+        requestAnimationFrame(() => buttonRefs.current[index]?.focus());
+        break;
+      }
+    }
+  }, [disabled, items, onChange]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          event.preventDefault();
+          moveSelection(1);
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          event.preventDefault();
+          moveSelection(-1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          selectFirstEnabled();
+          break;
+        case 'End':
+          event.preventDefault();
+          selectLastEnabled();
+          break;
+        case ' ': // fall through
+        case 'Enter':
+          event.preventDefault();
+          if (!disabled && !items[index]?.disabled) {
+            onChange(items[index].id);
+          }
+          break;
+        default:
+      }
+    },
+    [disabled, items, moveSelection, onChange, selectFirstEnabled, selectLastEnabled],
+  );
+
+  const containerClassName =
+    'relative inline-flex overflow-hidden rounded-full bg-surface/40 p-1 shadow-inner shadow-black/10';
+  const composedClassName = className ? `${containerClassName} ${className}` : containerClassName;
+  const translateX = segmentWidth * activeIndex;
+  const indicatorDuration = prefersReducedMotion ? 140 : 220;
+  const containerStyle: (CSSProperties & { '--segment-width'?: string }) | undefined = segmentWidth
+    ? { '--segment-width': `${segmentWidth}px` }
+    : undefined;
+  const indicatorStyles: CSSProperties = {
+    width: segmentWidth ? `${segmentWidth}px` : undefined,
+    transform: `translateX(${translateX}px)`,
+    transition: prefersReducedMotion
+      ? `transform ${indicatorDuration}ms linear`
+      : `transform ${indicatorDuration}ms cubic-bezier(0.2, 0.8, 0.2, 1)`,
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={composedClassName}
+      data-segmented
+      style={containerStyle}
+    >
+      <span
+        className="pointer-events-none absolute inset-y-1 left-1 z-0 rounded-full bg-accent text-transparent"
+        style={indicatorStyles}
+        aria-hidden
+      />
+      {items.map((item, index) => {
+        const isActive = item.id === value;
+        const isDisabled = disabled || item.disabled;
+        return (
+          <button
+            key={item.id}
+            ref={(element) => {
+              buttonRefs.current[index] = element;
+            }}
+            role="radio"
+            type="button"
+            aria-checked={isActive}
+            aria-disabled={isDisabled}
+            disabled={isDisabled}
+            onClick={() => onChange(item.id)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+            className={`relative z-10 flex h-10 items-center justify-center rounded-full px-4 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
+              isActive ? 'text-accent-contrast' : 'text-text-secondary hover:text-text-primary'
+            }`}
+            style={{
+              width: segmentWidth ? `${segmentWidth}px` : undefined,
+            }}
+          >
+            {item.label}
+          </button>
+        );
+      })}
+
+      <div ref={measurementRef} id={measurementId} className="pointer-events-none absolute left-0 top-0 h-0 overflow-hidden" aria-hidden>
+        {items.map((item) => (
+          <span key={item.id} data-segment-measure className="inline-block px-0 text-sm font-medium">
+            {item.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/usePrefersReducedMotion.ts
+++ b/src/lib/usePrefersReducedMotion.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook that tracks the user's `prefers-reduced-motion` media query.
+ * Use this to switch animations to a lightweight fallback when motion should be avoided.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const getInitialValue = () => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  };
+
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(getInitialValue);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from './context/AuthContext';
 import { ProjectProvider } from './context/ProjectContext';
 import { ThemeProvider } from './context/ThemeContext';
 import './styles/tailwind.css';
+import './styles/modal-transition.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,13 +1,15 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useState, type RefObject } from 'react';
 
 import { useAuth } from '../context/AuthContext';
 
 interface SignInPanelProps {
   onSuccess?: () => void;
   onSwitch?: () => void;
+  titleId?: string;
+  initialFocusRef?: RefObject<HTMLInputElement>;
 }
 
-export default function SignInPage({ onSuccess, onSwitch }: SignInPanelProps) {
+export default function SignInPage({ onSuccess, onSwitch, titleId, initialFocusRef }: SignInPanelProps) {
   const { signIn } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -41,7 +43,9 @@ export default function SignInPage({ onSuccess, onSwitch }: SignInPanelProps) {
   return (
     <div className="flex w-full flex-col gap-8">
       <header className="space-y-2 text-center">
-        <h2 className="text-3xl font-semibold text-text-primary">Welcome back</h2>
+        <h2 id={titleId ?? undefined} className="text-3xl font-semibold text-text-primary">
+          Welcome back
+        </h2>
         <p className="text-sm text-text-secondary">Sign in to access your profile.</p>
       </header>
 
@@ -52,6 +56,7 @@ export default function SignInPage({ onSuccess, onSwitch }: SignInPanelProps) {
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
+            ref={initialFocusRef ?? undefined}
             className="rounded border border-border bg-background px-3 py-2 text-base text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
             placeholder="you@example.com"
             autoComplete="email"

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,13 +1,15 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useState, type RefObject } from 'react';
 
 import { useAuth } from '../context/AuthContext';
 
 interface SignUpPanelProps {
   onSuccess?: () => void;
   onSwitch?: () => void;
+  titleId?: string;
+  initialFocusRef?: RefObject<HTMLInputElement>;
 }
 
-export default function SignUpPage({ onSuccess, onSwitch }: SignUpPanelProps) {
+export default function SignUpPage({ onSuccess, onSwitch, titleId, initialFocusRef }: SignUpPanelProps) {
   const { signUp, signIn } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -59,7 +61,9 @@ export default function SignUpPage({ onSuccess, onSwitch }: SignUpPanelProps) {
   return (
     <div className="flex w-full flex-col gap-8">
       <header className="space-y-2 text-center">
-        <h2 className="text-3xl font-semibold text-text-primary">Create your account</h2>
+        <h2 id={titleId ?? undefined} className="text-3xl font-semibold text-text-primary">
+          Create your account
+        </h2>
         <p className="text-sm text-text-secondary">
           Sign up with your email address to start building.
         </p>
@@ -72,6 +76,7 @@ export default function SignUpPage({ onSuccess, onSwitch }: SignUpPanelProps) {
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
+            ref={initialFocusRef ?? undefined}
             className="rounded border border-border bg-background px-3 py-2 text-base text-text-primary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
             placeholder="you@example.com"
             autoComplete="email"

--- a/src/styles/modal-transition.css
+++ b/src/styles/modal-transition.css
@@ -1,0 +1,71 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity var(--modal-overlay-duration, 200ms) var(--modal-easing, ease);
+}
+
+.modal-overlay[data-state='entering'],
+.modal-overlay[data-state='entered'] {
+  opacity: 1;
+}
+
+.modal-overlay[data-state='exiting'] {
+  opacity: 0;
+}
+
+.modal-panel {
+  position: relative;
+  opacity: 0;
+  --modal-translate-y: 1.5rem;
+  --modal-scale-rest: 1;
+  transition-property: opacity, transform;
+  transition-duration: var(--modal-panel-duration, 250ms);
+  transition-timing-function: var(--modal-easing, ease);
+  transform: translateY(var(--modal-translate-y)) scale(var(--modal-scale-rest));
+  will-change: transform, opacity;
+}
+
+.modal-panel[data-state='entering'],
+.modal-panel[data-state='entered'] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.modal-panel[data-state='exiting'] {
+  opacity: 0;
+  transform: translateY(var(--modal-translate-y)) scale(var(--modal-scale-rest));
+}
+
+.modal-panel[data-motion='reduced'] {
+  transform: none;
+  transition-duration: var(--modal-panel-duration, 150ms);
+}
+
+.modal-panel[data-motion='reduced'][data-state='exiting'] {
+  transform: none;
+}
+
+.modal-panel[data-motion='reduced'][data-state='entering'],
+.modal-panel[data-motion='reduced'][data-state='entered'] {
+  opacity: 1;
+}
+
+.modal-panel[data-motion='reduced'][data-state='exiting'] {
+  opacity: 0;
+}
+
+.modal-overlay[data-motion='reduced'] {
+  transition-duration: var(--modal-overlay-duration, 140ms);
+}
+
+@media (min-width: 640px) {
+  .modal-panel {
+    --modal-translate-y: 1rem;
+    --modal-scale-rest: 0.98;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared ModalTransition wrapper with reduced-motion aware animations and focus trapping
- introduce CloseButton and SegmentedControl components and apply them across dialogs and the project overview
- update authentication and asset browser panels to use the new motion, accessibility, and interaction standards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db7f739108832fbcae035c08ebe8e7