### PR TITLE
Add modal transition wrapper to new project dialog

### DIFF
--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -1,8 +1,9 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { ItemInput, ProjectItemType } from '../context/ProjectContext';
 import { ITEM_TYPE_DEFINITIONS } from '../constants/itemOptions';
 import CloseButton from './CloseButton';
+import ModalTransition from './ModalTransition';
 
 interface NewProjectDialogProps {
   open: boolean;
@@ -20,6 +21,8 @@ const emptyFormState = {
 
 function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
   const [formState, setFormState] = useState(emptyFormState);
+  const titleId = useId();
+  const nameInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (open) {
@@ -82,132 +85,136 @@ function NewProjectDialog({ open, onClose, onCreate }: NewProjectDialogProps) {
   const showCustomField =
     formState.variant.toLowerCase().includes('custom') || formState.itemType === 'custom';
 
-  if (!open) {
-    return null;
-  }
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/80 p-4">
-      <div className="w-full max-w-3xl rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60">
-        <div className="flex items-center justify-between border-b border-border/70 px-8 py-6">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">New Project</p>
-            <h2 className="mt-2 text-2xl font-semibold text-text-primary">Create a tabletop adventure workspace</h2>
-          </div>
-          <CloseButton onClick={onClose} label="Close new project dialog" className="ml-2 shrink-0" />
+    <ModalTransition
+      open={open}
+      onClose={onClose}
+      labelledBy={titleId}
+      initialFocusRef={nameInputRef}
+      overlayClassName="bg-overlay/80 p-4"
+      panelClassName="flex w-full max-w-3xl flex-col overflow-hidden rounded-3xl border border-border bg-surface-elevated/95 shadow-2xl shadow-black/60"
+    >
+      <div className="flex items-center justify-between border-b border-border/70 px-8 py-6">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent/70">New Project</p>
+          <h2 id={titleId} className="mt-2 text-2xl font-semibold text-text-primary">
+            Create a tabletop adventure workspace
+          </h2>
         </div>
+        <CloseButton onClick={onClose} label="Close new project dialog" className="ml-2 shrink-0" />
+      </div>
 
-        <form onSubmit={handleSubmit} className="grid gap-8 px-8 py-6 sm:grid-cols-2">
-          <div className="space-y-4">
-            <label className="block text-sm font-semibold text-text-secondary">
-              Project name
+      <form onSubmit={handleSubmit} className="grid flex-1 gap-8 px-8 py-6 sm:grid-cols-2">
+        <div className="space-y-4">
+          <label className="block text-sm font-semibold text-text-secondary">
+            Project name
+            <input
+              value={formState.name}
+              ref={nameInputRef}
+              onChange={(event) => setFormState((state) => ({ ...state, name: event.target.value }))}
+              placeholder="e.g. Clockwork Isles Campaign"
+              className="mt-2 w-full rounded-xl border border-border bg-surface-muted/60 px-4 py-2 text-base text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
+              required
+            />
+          </label>
+
+          <div className="rounded-2xl border border-border/80 bg-surface-muted/40 p-4">
+            <p className="text-sm font-semibold text-text-secondary">First item</p>
+            <p className="mt-1 text-xs text-text-muted">
+              Give your project a head start with the first board, deck, or poster.
+            </p>
+
+            <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
+              Item title
               <input
-                value={formState.name}
-                onChange={(event) => setFormState((state) => ({ ...state, name: event.target.value }))}
-                placeholder="e.g. Clockwork Isles Campaign"
-                className="mt-2 w-full rounded-xl border border-border bg-surface-muted/60 px-4 py-2 text-base text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
-                required
+                value={formState.itemName}
+                onChange={(event) => setFormState((state) => ({ ...state, itemName: event.target.value }))}
+                placeholder="e.g. Encounter Deck"
+                className="mt-2 w-full rounded-lg border border-border bg-surface-muted/60 px-3 py-2 text-sm text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
               />
             </label>
+          </div>
+        </div>
 
-            <div className="rounded-2xl border border-border/80 bg-surface-muted/40 p-4">
-              <p className="text-sm font-semibold text-text-secondary">First item</p>
-              <p className="mt-1 text-xs text-text-muted">
-                Give your project a head start with the first board, deck, or poster.
-              </p>
-
-              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
-                Item title
-                <input
-                  value={formState.itemName}
-                  onChange={(event) => setFormState((state) => ({ ...state, itemName: event.target.value }))}
-                  placeholder="e.g. Encounter Deck"
-                  className="mt-2 w-full rounded-lg border border-border bg-surface-muted/60 px-3 py-2 text-sm text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
-                />
-              </label>
-            </div>
+        <div className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 gap-3">
+            {ITEM_TYPE_DEFINITIONS.map((type) => (
+              <button
+                key={type.id}
+                type="button"
+                onClick={() =>
+                  setFormState((state) => ({
+                    ...state,
+                    itemType: type.id,
+                    variant: type.variants[0],
+                    customDetails: '',
+                  }))
+                }
+                className={`rounded-2xl border px-4 py-4 text-left transition ${
+                  formState.itemType === type.id
+                    ? 'border-accent/70 bg-accent/10 text-text-primary'
+                    : 'border-border/80 bg-surface/50 text-text-secondary hover:border-border/60 hover:bg-surface-muted'
+                }`}
+              >
+                <p className="text-sm font-semibold text-text-primary">{type.name}</p>
+                <p className="mt-1 text-xs text-text-muted">{type.description}</p>
+              </button>
+            ))}
           </div>
 
-          <div className="flex flex-col gap-4">
-            <div className="grid grid-cols-2 gap-3">
-              {ITEM_TYPE_DEFINITIONS.map((type) => (
+          <div className="rounded-2xl border border-border/80 bg-surface/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">Format</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {typeDefinition.variants.map((variant) => (
                 <button
-                  key={type.id}
+                  key={variant}
                   type="button"
-                  onClick={() =>
-                    setFormState((state) => ({
-                      ...state,
-                      itemType: type.id,
-                      variant: type.variants[0],
-                      customDetails: '',
-                    }))
-                  }
-                  className={`rounded-2xl border px-4 py-4 text-left transition ${
-                    formState.itemType === type.id
-                      ? 'border-accent/70 bg-accent/10 text-text-primary'
-                      : 'border-border/80 bg-surface/50 text-text-secondary hover:border-border/60 hover:bg-surface-muted'
+                  onClick={() => setFormState((state) => ({ ...state, variant }))}
+                  className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                    formState.variant === variant
+                      ? 'bg-accent text-accent-contrast'
+                      : 'bg-surface-muted text-text-secondary hover:bg-surface-muted/80'
                   }`}
                 >
-                  <p className="text-sm font-semibold text-text-primary">{type.name}</p>
-                  <p className="mt-1 text-xs text-text-muted">{type.description}</p>
+                  {variant}
                 </button>
               ))}
             </div>
 
-            <div className="rounded-2xl border border-border/80 bg-surface/60 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">Format</p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {typeDefinition.variants.map((variant) => (
-                  <button
-                    key={variant}
-                    type="button"
-                    onClick={() => setFormState((state) => ({ ...state, variant }))}
-                    className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
-                      formState.variant === variant
-                        ? 'bg-accent text-accent-contrast'
-                        : 'bg-surface-muted text-text-secondary hover:bg-surface-muted/80'
-                    }`}
-                  >
-                    {variant}
-                  </button>
-                ))}
-              </div>
-
-              {showCustomField && (
-                <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
-                  Custom details
-                  <input
-                    value={formState.customDetails}
-                    onChange={(event) => setFormState((state) => ({ ...state, customDetails: event.target.value }))}
-                    placeholder="Add size or notes"
-                    className="mt-2 w-full rounded-lg border border-border bg-surface-muted/60 px-3 py-2 text-sm text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
-                  />
-                </label>
-              )}
-            </div>
+            {showCustomField && (
+              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">
+                Custom details
+                <input
+                  value={formState.customDetails}
+                  onChange={(event) => setFormState((state) => ({ ...state, customDetails: event.target.value }))}
+                  placeholder="Add size or notes"
+                  className="mt-2 w-full rounded-lg border border-border bg-surface-muted/60 px-3 py-2 text-sm text-text-primary outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40"
+                />
+              </label>
+            )}
           </div>
+        </div>
 
-          <div className="sm:col-span-2 flex flex-col gap-3 border-t border-border/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs text-text-muted">You can add more items or assets after your project is created.</p>
-            <div className="flex gap-3">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-full border border-border/70 px-5 py-2 text-sm font-semibold text-text-secondary transition hover:border-accent hover:text-text-primary"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                className="rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast transition hover:bg-accent-strong"
-              >
-                Create project
-              </button>
-            </div>
+        <div className="sm:col-span-2 flex flex-col gap-3 border-t border-border/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-text-muted">You can add more items or assets after your project is created.</p>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full border border-border/70 px-5 py-2 text-sm font-semibold text-text-secondary transition hover:border-accent hover:text-text-primary"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast transition hover:bg-accent-strong"
+            >
+              Create project
+            </button>
           </div>
-        </form>
-      </div>
-    </div>
+        </div>
+      </form>
+    </ModalTransition>
   );
 }
 


### PR DESCRIPTION
## Summary
- wrap the New Project dialog with the shared ModalTransition component for consistent fade animations
- set initial focus to the project name field and wire modal accessibility ids while preserving existing form behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db8592b12c832f9ecb18154bc123a7