### PR TITLE
Fix action menu header collapse spacing

### DIFF
--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -344,10 +344,14 @@ function ProjectPage() {
   return (
     <div className="flex min-h-screen w-full overflow-hidden">
       <aside className={asideDynamicClasses}>
-        <div className="flex items-start justify-between gap-3 border-b border-border/80 px-3 py-4">
+        <div
+          className={`flex items-start justify-between gap-3 border-b border-border/80 px-3 transition-all duration-300 ${
+            isCollapsed ? 'py-2' : 'py-4'
+          }`}
+        >
           <div
-            className={`flex flex-1 flex-col gap-1 overflow-hidden transition-opacity duration-300 ${
-              isCollapsed ? 'pointer-events-none opacity-0' : 'opacity-100'
+            className={`flex flex-1 flex-col gap-1 overflow-hidden transition-[max-height,opacity] duration-300 ${
+              isCollapsed ? 'pointer-events-none max-h-0 opacity-0' : 'max-h-24 opacity-100'
             }`}
             aria-hidden={isCollapsed}
           >


### PR DESCRIPTION
## Summary
- adjust the action menu header padding when collapsed so the divider stays aligned
- collapse the project title block height with the sidebar to prevent the border from shifting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc15bf22c4832faeb6828ac08e5687