### PR TITLE
Make header sticky and remove footer panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,7 @@ function App() {
   return (
     <div className="flex min-h-screen flex-col bg-background font-sans text-text-primary">
       {!isProjectRoute && (
-        <header className="border-b border-border bg-surface/90">
+        <header className="sticky top-0 z-50 border-b border-border bg-surface/90 backdrop-blur">
           <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 py-6 text-center sm:flex-row sm:items-center sm:justify-between">
             <h1 className="text-2xl font-semibold tracking-tight text-text-primary sm:text-3xl">
               Tabletop Creator – Your Friendly Game Design Companion
@@ -107,13 +107,6 @@ function App() {
           <Route path="/projects/:projectId" element={<ProjectPage />} />
         </Routes>
       </main>
-
-      <footer className="border-t border-border bg-surface/80">
-        <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-6 py-6 text-center text-sm text-text-muted sm:flex-row sm:justify-between">
-          <p>&copy; {new Date().getFullYear()} Tabletop Creator. All rights reserved.</p>
-          <p className="text-xs sm:text-sm">Crafted with Vite, React, TypeScript, and Tailwind CSS.</p>
-        </div>
-      </footer>
 
       <AuthOverlay
         open={Boolean(authMode)}


### PR DESCRIPTION
## Summary
- make the top panel stick to the top of the viewport on non-project pages
- remove the bottom panel from the application layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd56d11874832f8ab04fa23d0c20a3