### PR TITLE
Fix project page crash caused by orderedItems initialization order

### DIFF
--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -443,6 +443,23 @@ function ProjectPage() {
     [handleCloseSearchPanel, handleLocateAsset],
   );
 
+  const orderedItems = useMemo(() => {
+    if (!project) {
+      return [];
+    }
+
+    if (orderedItemIds.length === 0) {
+      return project.items;
+    }
+
+    const byId = new Map(project.items.map((item) => [item.id, item]));
+    const arranged: Project['items'] = orderedItemIds
+      .map((id) => byId.get(id))
+      .filter((item): item is Project['items'][number] => Boolean(item));
+    const leftovers = project.items.filter((item) => !orderedItemIds.includes(item.id));
+    return [...arranged, ...leftovers];
+  }, [orderedItemIds, project]);
+
   const filteredItems = useMemo(() => {
     if (!project) {
       return [];
@@ -514,23 +531,6 @@ function ProjectPage() {
       return [...additions, ...preservedOrder];
     });
   }, [itemIdsSignature, project]);
-
-  const orderedItems = useMemo(() => {
-    if (!project) {
-      return [];
-    }
-
-    if (orderedItemIds.length === 0) {
-      return project.items;
-    }
-
-    const byId = new Map(project.items.map((item) => [item.id, item]));
-    const arranged: Project['items'] = orderedItemIds
-      .map((id) => byId.get(id))
-      .filter((item): item is Project['items'][number] => Boolean(item));
-    const leftovers = project.items.filter((item) => !orderedItemIds.includes(item.id));
-    return [...arranged, ...leftovers];
-  }, [orderedItemIds, project]);
 
   const stripLayoutSignature = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- move the `orderedItems` memo above other memos that depend on it so it is initialized before use
- ensure the project page can render both project content and the "project not found" fallback without crashing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7ec67e30832fb84f6ef9d5f61b59