### PR TITLE
Add dependency check before dev/build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently -k \"npm:dev:server\" \"npm:dev:client\"",
+    "dev": "npm run check:deps && concurrently -k \"npm:dev:server\" \"npm:dev:client\"",
     "dev:client": "vite",
     "dev:server": "tsx watch server/index.ts",
-    "build": "tsc -p tsconfig.server.json && vite build",
+    "build": "npm run check:deps && tsc -p tsconfig.server.json && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "typecheck:server": "tsc -p tsconfig.server.json --noEmit"
+    "typecheck:server": "tsc -p tsconfig.server.json --noEmit",
+    "check:deps": "node scripts/check-required-deps.cjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/check-required-deps.cjs
+++ b/scripts/check-required-deps.cjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const path = require('node:path');
+
+const packages = ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'];
+const missing = [];
+
+for (const pkg of packages) {
+  try {
+    require.resolve(pkg);
+  } catch (error) {
+    missing.push(pkg);
+  }
+}
+
+if (missing.length > 0) {
+  const relativeScript = path.relative(process.cwd(), __filename);
+  console.error(
+    `\nMissing required packages: ${missing.join(', ')}.\n` +
+      'Run "npm install" to install the latest dependencies before starting the dev server.\n',
+  );
+  console.error(`Detected by ${relativeScript}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a dependency check script to fail fast when drag-and-drop packages are missing
- wire the new check into the dev and build npm scripts so the app never starts without required modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd9bd8f96c832f97239a22eb9f327d